### PR TITLE
fix: robust CLI installer for all environments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/open-context-orchestrator/oco"

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "oco-vscode",
   "displayName": "Open Context Orchestrator",
   "description": "Intelligent orchestration middleware for coding assistants",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "publisher": "oco",
   "license": "Apache-2.0",
   "engines": {

--- a/cli.mjs
+++ b/cli.mjs
@@ -19,7 +19,7 @@ import { execSync } from 'node:child_process';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_SRC = join(__dirname, 'plugin');
 const MANIFEST_FILE = '.oco-install-manifest.json';
-const VERSION = '0.1.0';
+const VERSION = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8')).version;
 
 // --- CLI Argument Parsing ---
 
@@ -66,9 +66,14 @@ async function install() {
       continue;
     }
 
-    cpSync(src, dest);
-    copied++;
-    console.log(`  copy  ${relPath}`);
+    try {
+      cpSync(src, dest, { force: true });
+      copied++;
+      console.log(`  copy  ${relPath}`);
+    } catch (err) {
+      skipped++;
+      console.log(`  skip  ${relPath} (${err.code || 'copy failed'})`);
+    }
   }
 
   // 3. Merge settings.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oco-claude-plugin",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "OCO Claude Code plugin — safety hooks, skills, agents, and MCP tools for any project",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- Read VERSION from package.json instead of hardcoding it
- Wrap `cpSync` in try/catch — skip files that fail instead of crashing
- Add `force: true` to `cpSync` for reliable overwrites on Windows
- Bump to v0.3.1

## Test plan
- [x] `cargo check` passes
- [x] `node cli.mjs install --global --force` succeeds (14/14 files)
- [x] `node cli.mjs status --global` reports v0.3.1
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)