### PR TITLE
fix: make OCO skill descriptions auto-activate like Superpower

### DIFF
--- a/.agents/skills/oco-inspect-repo-area/SKILL.md
+++ b/.agents/skills/oco-inspect-repo-area/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-inspect-repo-area
-description: Explore and understand a specific area of the repository using OCO-backed code intelligence. Use when the task is exploratory and repo-specific.
+description: >
+  Structured codebase exploration with OCO-backed code intelligence.
+  Auto-activates when the user asks to explore, understand, explain how a module works,
+  a feature, an architecture, a data flow, or asks "how does this work", "where is",
+  "show me", "what is this module". Uses yoyo search/inspect for symbol-aware results
+  instead of raw grep. Enforces: compact summary before any action, selective reading
+  (no directory dumps), explicit confidence level.
 triggers:
   - "explore"
   - "understand"

--- a/.agents/skills/oco-investigate-bug/SKILL.md
+++ b/.agents/skills/oco-investigate-bug/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-investigate-bug
-description: Systematic bug investigation without a full stacktrace. Enforces evidence-first debugging with reproduction and root cause analysis.
+description: >
+  Systematic evidence-first bug investigation without a full stacktrace.
+  Auto-activates when the user reports a bug, broken behavior, unexpected results, a regression,
+  something not working, or a problem without a clear error message.
+  Enforces strict workflow: understand symptom → narrow scope → gather evidence → reproduce →
+  root cause analysis → fix ONLY after proof. Never guess at fixes.
+  Also auto-activates after 2 failed attempts to fix the same problem.
 triggers:
   - "debug"
   - "bug"

--- a/.agents/skills/oco-safe-refactor/SKILL.md
+++ b/.agents/skills/oco-safe-refactor/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-safe-refactor
-description: Structured refactoring with impact analysis, staged changes, and verification. Use for renames, restructuring, module extraction.
+description: >
+  Structured refactoring with impact analysis, staged changes, and verification.
+  Auto-activates when the user asks to refactor, rename, restructure, extract, move, reorganize,
+  decouple, or split code. Enforces a strict workflow: impact analysis before any change, staged
+  modifications (implementation → consumers → tests → docs), full verification after each stage,
+  subagent review if >10 files impacted. MANDATORY for all refactoring — never rename/move without
+  this skill.
 triggers:
   - "refactor"
   - "rename"

--- a/.agents/skills/oco-trace-stack/SKILL.md
+++ b/.agents/skills/oco-trace-stack/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: oco-trace-stack
-description: Analyze a stack trace or runtime error to identify root cause. Use when a stacktrace or runtime error is present.
+description: >
+  Stack trace and runtime error analysis to identify root cause.
+  Auto-activates when the user pastes a stacktrace, traceback, panic, exception, crash,
+  or error with line number. Also detects runtime errors in command output (build, test, run).
+  Enforces workflow: parse trace → map to code → inspect suspect regions → ranked hypotheses →
+  verify before fixing. Never propose a fix without reading the failing code.
 triggers:
   - "stacktrace"
   - "stack trace"

--- a/.agents/skills/oco-verify-fix/SKILL.md
+++ b/.agents/skills/oco-verify-fix/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-verify-fix
-description: Run verification suite after code changes. Enforces build, test, lint, typecheck discipline with evidence-based completion.
+description: >
+  Mandatory verification suite after any code change.
+  Auto-activates after every source file modification, even trivial ones (one-liner).
+  Detects project type (Cargo.toml, package.json, pyproject.toml, go.mod, .csproj) and runs
+  in order: build → types → lint → tests. Produces a PASS/FAIL/PARTIAL verdict.
+  NON-NEGOTIABLE: never consider a change complete without running this skill.
+  Also activates when the user asks to verify, test, validate, or check their changes.
 triggers:
   - "verify"
   - "check my changes"

--- a/.claude/skills/oco-inspect-repo-area/SKILL.md
+++ b/.claude/skills/oco-inspect-repo-area/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-inspect-repo-area
-description: Explore and understand a specific area of the repository using OCO-backed code intelligence. Use when the task is exploratory and repo-specific.
+description: >
+  Structured codebase exploration with OCO-backed code intelligence.
+  Auto-activates when the user asks to explore, understand, explain how a module works,
+  a feature, an architecture, a data flow, or asks "how does this work", "where is",
+  "show me", "what is this module". Uses yoyo search/inspect for symbol-aware results
+  instead of raw grep. Enforces: compact summary before any action, selective reading
+  (no directory dumps), explicit confidence level.
 triggers:
   - "explore"
   - "understand"

--- a/.claude/skills/oco-investigate-bug/SKILL.md
+++ b/.claude/skills/oco-investigate-bug/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-investigate-bug
-description: Systematic bug investigation without a full stacktrace. Enforces evidence-first debugging with reproduction and root cause analysis.
+description: >
+  Systematic evidence-first bug investigation without a full stacktrace.
+  Auto-activates when the user reports a bug, broken behavior, unexpected results, a regression,
+  something not working, or a problem without a clear error message.
+  Enforces strict workflow: understand symptom → narrow scope → gather evidence → reproduce →
+  root cause analysis → fix ONLY after proof. Never guess at fixes.
+  Also auto-activates after 2 failed attempts to fix the same problem.
 triggers:
   - "debug"
   - "bug"

--- a/.claude/skills/oco-safe-refactor/SKILL.md
+++ b/.claude/skills/oco-safe-refactor/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-safe-refactor
-description: Structured refactoring with impact analysis, staged changes, and verification. Use for renames, restructuring, module extraction.
+description: >
+  Structured refactoring with impact analysis, staged changes, and verification.
+  Auto-activates when the user asks to refactor, rename, restructure, extract, move, reorganize,
+  decouple, or split code. Enforces a strict workflow: impact analysis before any change, staged
+  modifications (implementation → consumers → tests → docs), full verification after each stage,
+  subagent review if >10 files impacted. MANDATORY for all refactoring — never rename/move without
+  this skill.
 triggers:
   - "refactor"
   - "rename"

--- a/.claude/skills/oco-trace-stack/SKILL.md
+++ b/.claude/skills/oco-trace-stack/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: oco-trace-stack
-description: Analyze a stack trace or runtime error to identify root cause. Use when a stacktrace or runtime error is present.
+description: >
+  Stack trace and runtime error analysis to identify root cause.
+  Auto-activates when the user pastes a stacktrace, traceback, panic, exception, crash,
+  or error with line number. Also detects runtime errors in command output (build, test, run).
+  Enforces workflow: parse trace → map to code → inspect suspect regions → ranked hypotheses →
+  verify before fixing. Never propose a fix without reading the failing code.
 triggers:
   - "stacktrace"
   - "stack trace"

--- a/.claude/skills/oco-verify-fix/SKILL.md
+++ b/.claude/skills/oco-verify-fix/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-verify-fix
-description: Run verification suite after code changes. Enforces build, test, lint, typecheck discipline with evidence-based completion.
+description: >
+  Mandatory verification suite after any code change.
+  Auto-activates after every source file modification, even trivial ones (one-liner).
+  Detects project type (Cargo.toml, package.json, pyproject.toml, go.mod, .csproj) and runs
+  in order: build → types → lint → tests. Produces a PASS/FAIL/PARTIAL verdict.
+  NON-NEGOTIABLE: never consider a change complete without running this skill.
+  Also activates when the user asks to verify, test, validate, or check their changes.
 triggers:
   - "verify"
   - "check my changes"

--- a/oco-plugin/skills/oco-inspect-repo-area/SKILL.md
+++ b/oco-plugin/skills/oco-inspect-repo-area/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-inspect-repo-area
-description: Explore and understand a specific area of the repository using OCO-backed code intelligence. Use when the task is exploratory and repo-specific.
+description: >
+  Structured codebase exploration with OCO-backed code intelligence.
+  Auto-activates when the user asks to explore, understand, explain how a module works,
+  a feature, an architecture, a data flow, or asks "how does this work", "where is",
+  "show me", "what is this module". Uses yoyo search/inspect for symbol-aware results
+  instead of raw grep. Enforces: compact summary before any action, selective reading
+  (no directory dumps), explicit confidence level.
 triggers:
   - "explore"
   - "understand"

--- a/oco-plugin/skills/oco-investigate-bug/SKILL.md
+++ b/oco-plugin/skills/oco-investigate-bug/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-investigate-bug
-description: Systematic bug investigation without a full stacktrace. Enforces evidence-first debugging with reproduction and root cause analysis.
+description: >
+  Systematic evidence-first bug investigation without a full stacktrace.
+  Auto-activates when the user reports a bug, broken behavior, unexpected results, a regression,
+  something not working, or a problem without a clear error message.
+  Enforces strict workflow: understand symptom → narrow scope → gather evidence → reproduce →
+  root cause analysis → fix ONLY after proof. Never guess at fixes.
+  Also auto-activates after 2 failed attempts to fix the same problem.
 triggers:
   - "debug"
   - "bug"

--- a/oco-plugin/skills/oco-safe-refactor/SKILL.md
+++ b/oco-plugin/skills/oco-safe-refactor/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-safe-refactor
-description: Structured refactoring with impact analysis, staged changes, and verification. Use for renames, restructuring, module extraction.
+description: >
+  Structured refactoring with impact analysis, staged changes, and verification.
+  Auto-activates when the user asks to refactor, rename, restructure, extract, move, reorganize,
+  decouple, or split code. Enforces a strict workflow: impact analysis before any change, staged
+  modifications (implementation → consumers → tests → docs), full verification after each stage,
+  subagent review if >10 files impacted. MANDATORY for all refactoring — never rename/move without
+  this skill.
 triggers:
   - "refactor"
   - "rename"

--- a/oco-plugin/skills/oco-trace-stack/SKILL.md
+++ b/oco-plugin/skills/oco-trace-stack/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: oco-trace-stack
-description: Analyze a stack trace or runtime error to identify root cause. Use when a stacktrace or runtime error is present.
+description: >
+  Stack trace and runtime error analysis to identify root cause.
+  Auto-activates when the user pastes a stacktrace, traceback, panic, exception, crash,
+  or error with line number. Also detects runtime errors in command output (build, test, run).
+  Enforces workflow: parse trace → map to code → inspect suspect regions → ranked hypotheses →
+  verify before fixing. Never propose a fix without reading the failing code.
 triggers:
   - "stacktrace"
   - "stack trace"

--- a/oco-plugin/skills/oco-verify-fix/SKILL.md
+++ b/oco-plugin/skills/oco-verify-fix/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-verify-fix
-description: Run verification suite after code changes. Enforces build, test, lint, typecheck discipline with evidence-based completion.
+description: >
+  Mandatory verification suite after any code change.
+  Auto-activates after every source file modification, even trivial ones (one-liner).
+  Detects project type (Cargo.toml, package.json, pyproject.toml, go.mod, .csproj) and runs
+  in order: build → types → lint → tests. Produces a PASS/FAIL/PARTIAL verdict.
+  NON-NEGOTIABLE: never consider a change complete without running this skill.
+  Also activates when the user asks to verify, test, validate, or check their changes.
 triggers:
   - "verify"
   - "check my changes"

--- a/plugin/skills/oco-inspect-repo-area/SKILL.md
+++ b/plugin/skills/oco-inspect-repo-area/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-inspect-repo-area
-description: Explore and understand a specific area of the repository using OCO-backed code intelligence. Use when the task is exploratory and repo-specific.
+description: >
+  Structured codebase exploration with OCO-backed code intelligence.
+  Auto-activates when the user asks to explore, understand, explain how a module works,
+  a feature, an architecture, a data flow, or asks "how does this work", "where is",
+  "show me", "what is this module". Uses yoyo search/inspect for symbol-aware results
+  instead of raw grep. Enforces: compact summary before any action, selective reading
+  (no directory dumps), explicit confidence level.
 triggers:
   - "explore"
   - "understand"

--- a/plugin/skills/oco-investigate-bug/SKILL.md
+++ b/plugin/skills/oco-investigate-bug/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-investigate-bug
-description: Systematic bug investigation without a full stacktrace. Enforces evidence-first debugging with reproduction and root cause analysis.
+description: >
+  Systematic evidence-first bug investigation without a full stacktrace.
+  Auto-activates when the user reports a bug, broken behavior, unexpected results, a regression,
+  something not working, or a problem without a clear error message.
+  Enforces strict workflow: understand symptom → narrow scope → gather evidence → reproduce →
+  root cause analysis → fix ONLY after proof. Never guess at fixes.
+  Also auto-activates after 2 failed attempts to fix the same problem.
 triggers:
   - "debug"
   - "bug"

--- a/plugin/skills/oco-safe-refactor/SKILL.md
+++ b/plugin/skills/oco-safe-refactor/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-safe-refactor
-description: Structured refactoring with impact analysis, staged changes, and verification. Use for renames, restructuring, module extraction.
+description: >
+  Structured refactoring with impact analysis, staged changes, and verification.
+  Auto-activates when the user asks to refactor, rename, restructure, extract, move, reorganize,
+  decouple, or split code. Enforces a strict workflow: impact analysis before any change, staged
+  modifications (implementation → consumers → tests → docs), full verification after each stage,
+  subagent review if >10 files impacted. MANDATORY for all refactoring — never rename/move without
+  this skill.
 triggers:
   - "refactor"
   - "rename"

--- a/plugin/skills/oco-trace-stack/SKILL.md
+++ b/plugin/skills/oco-trace-stack/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: oco-trace-stack
-description: Analyze a stack trace or runtime error to identify root cause. Use when a stacktrace or runtime error is present.
+description: >
+  Stack trace and runtime error analysis to identify root cause.
+  Auto-activates when the user pastes a stacktrace, traceback, panic, exception, crash,
+  or error with line number. Also detects runtime errors in command output (build, test, run).
+  Enforces workflow: parse trace → map to code → inspect suspect regions → ranked hypotheses →
+  verify before fixing. Never propose a fix without reading the failing code.
 triggers:
   - "stacktrace"
   - "stack trace"

--- a/plugin/skills/oco-verify-fix/SKILL.md
+++ b/plugin/skills/oco-verify-fix/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: oco-verify-fix
-description: Run verification suite after code changes. Enforces build, test, lint, typecheck discipline with evidence-based completion.
+description: >
+  Mandatory verification suite after any code change.
+  Auto-activates after every source file modification, even trivial ones (one-liner).
+  Detects project type (Cargo.toml, package.json, pyproject.toml, go.mod, .csproj) and runs
+  in order: build → types → lint → tests. Produces a PASS/FAIL/PARTIAL verdict.
+  NON-NEGOTIABLE: never consider a change complete without running this skill.
+  Also activates when the user asks to verify, test, validate, or check their changes.
 triggers:
   - "verify"
   - "check my changes"


### PR DESCRIPTION
## Summary

- Rewrite all 5 OCO skill descriptions to use "Auto-activates when..." pattern
- Match the description depth and imperative tone of `ultimate-design-system` (Superpower)
- Patch all 4 copy locations (`.agents/`, `.claude/`, `oco-plugin/`, `plugin/`) — 20 files total

## Problem

OCO skills had minimal one-line descriptions:
```
description: Structured refactoring with impact analysis. Use for renames.
```

Claude Code uses the `description:` field from SKILL.md frontmatter as the **sole signal** to decide whether to auto-invoke a skill. Without explicit "Auto-activates when..." language, Claude never triggered OCO skills automatically — users had to manually invoke `/oco-safe-refactor`.

Meanwhile, Superpower skills like `ultimate-design-system` worked plug-and-play because their descriptions were rich, imperative, and listed specific user intents.

## Fix

Each OCO skill description now:
- Starts with purpose, then **"Auto-activates when..."** with exhaustive intent patterns
- Uses imperative language: MANDATORY, NON-NEGOTIABLE, "never... without"
- Expanded from 1 line to 6-7 lines (matching Superpower depth)
- Lists natural phrases users actually say

## Test plan

- [ ] Start a new Claude Code session, ask to "rename a function" → should auto-trigger `/oco-safe-refactor`
- [ ] Make a code change, finish → should auto-trigger `/oco-verify-fix`
- [ ] Report "this is broken" → should auto-trigger `/oco-investigate-bug`
- [ ] Paste a stacktrace → should auto-trigger `/oco-trace-stack`
- [ ] Ask "how does this module work" → should auto-trigger `/oco-inspect-repo-area`

🤖 Generated with [Claude Code](https://claude.com/claude-code)