### PR TITLE
fix: cross-platform cache dir (Windows/Linux/Mac)

### DIFF
--- a/.claude/hooks/lib/utils.mjs
+++ b/.claude/hooks/lib/utils.mjs
@@ -46,7 +46,10 @@ export function getStateDir() {
   }
 
   const hash = createHash('md5').update(workspaceRoot).digest('hex').slice(0, 12);
-  const cacheRoot = process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco');
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
 
   const stateDir = join(cacheRoot, `session-${hash}`);
   try {

--- a/.claude/hooks/post-tool-use.mjs
+++ b/.claude/hooks/post-tool-use.mjs
@@ -17,7 +17,11 @@ function getStateDir() {
   let root;
   try { root = require('node:child_process').execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim(); } catch { root = process.env.CLAUDE_PROJECT_DIR || process.cwd(); }
   const hash = createHash('md5').update(root).digest('hex').slice(0, 12);
-  const dir = join(process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco'), `session-${hash}`);
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
+  const dir = join(cacheRoot, `session-${hash}`);
   try { mkdirSync(dir, { recursive: true }); if (lstatSync(dir).isSymbolicLink()) return join(tmpdir(), 'oco-fallback'); } catch {}
   return dir;
 }

--- a/.claude/hooks/pre-tool-use.mjs
+++ b/.claude/hooks/pre-tool-use.mjs
@@ -17,7 +17,11 @@ function getStateDir() {
   let root;
   try { root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim(); } catch { root = process.env.CLAUDE_PROJECT_DIR || process.cwd(); }
   const hash = createHash('md5').update(root).digest('hex').slice(0, 12);
-  const dir = join(process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco'), `session-${hash}`);
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
+  const dir = join(cacheRoot, `session-${hash}`);
   try { mkdirSync(dir, { recursive: true }); if (lstatSync(dir).isSymbolicLink()) return join(tmpdir(), 'oco-fallback'); } catch {}
   return dir;
 }

--- a/.claude/hooks/stop.mjs
+++ b/.claude/hooks/stop.mjs
@@ -17,7 +17,11 @@ function getStateDir() {
   let root;
   try { root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim(); } catch { root = process.env.CLAUDE_PROJECT_DIR || process.cwd(); }
   const hash = createHash('md5').update(root).digest('hex').slice(0, 12);
-  const dir = join(process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco'), `session-${hash}`);
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
+  const dir = join(cacheRoot, `session-${hash}`);
   try { mkdirSync(dir, { recursive: true }); if (lstatSync(dir).isSymbolicLink()) return join(tmpdir(), 'oco-fallback'); } catch {}
   return dir;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.3] — 2026-03-25
+
+### Fixed
+- Cross-platform cache dir: use `%LOCALAPPDATA%\oco` on Windows, `~/.cache/oco` on Linux/Mac
+- Remove dead code in `findProjectRoot` (unused URL parsing)
+- Fix cache path in all 8 hook files (plugin/ + .claude/) for Windows compatibility
+
 ## [0.3.2] — 2026-03-25
 
 ### Fixed

--- a/cli.mjs
+++ b/cli.mjs
@@ -254,7 +254,6 @@ function resolveTarget() {
 function findProjectRoot(dir) {
   const markers = ['package.json', 'Cargo.toml', 'pyproject.toml', 'go.mod', '.git'];
   let current = resolve(dir);
-  const { root } = new URL('file:///' + current.replace(/\\/g, '/'));
 
   while (true) {
     for (const marker of markers) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oco-claude-plugin",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "OCO Claude Code plugin — safety hooks, skills, agents, and MCP tools for any project",
   "type": "module",
   "bin": {

--- a/plugin/hooks/lib/utils.mjs
+++ b/plugin/hooks/lib/utils.mjs
@@ -46,7 +46,10 @@ export function getStateDir() {
   }
 
   const hash = createHash('md5').update(workspaceRoot).digest('hex').slice(0, 12);
-  const cacheRoot = process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco');
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
 
   const stateDir = join(cacheRoot, `session-${hash}`);
   try {

--- a/plugin/hooks/post-tool-use.mjs
+++ b/plugin/hooks/post-tool-use.mjs
@@ -17,7 +17,11 @@ function getStateDir() {
   let root;
   try { root = require('node:child_process').execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim(); } catch { root = process.env.CLAUDE_PROJECT_DIR || process.cwd(); }
   const hash = createHash('md5').update(root).digest('hex').slice(0, 12);
-  const dir = join(process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco'), `session-${hash}`);
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
+  const dir = join(cacheRoot, `session-${hash}`);
   try { mkdirSync(dir, { recursive: true }); if (lstatSync(dir).isSymbolicLink()) return join(tmpdir(), 'oco-fallback'); } catch {}
   return dir;
 }

--- a/plugin/hooks/pre-tool-use.mjs
+++ b/plugin/hooks/pre-tool-use.mjs
@@ -17,7 +17,11 @@ function getStateDir() {
   let root;
   try { root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim(); } catch { root = process.env.CLAUDE_PROJECT_DIR || process.cwd(); }
   const hash = createHash('md5').update(root).digest('hex').slice(0, 12);
-  const dir = join(process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco'), `session-${hash}`);
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
+  const dir = join(cacheRoot, `session-${hash}`);
   try { mkdirSync(dir, { recursive: true }); if (lstatSync(dir).isSymbolicLink()) return join(tmpdir(), 'oco-fallback'); } catch {}
   return dir;
 }

--- a/plugin/hooks/stop.mjs
+++ b/plugin/hooks/stop.mjs
@@ -17,7 +17,11 @@ function getStateDir() {
   let root;
   try { root = execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8', timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim(); } catch { root = process.env.CLAUDE_PROJECT_DIR || process.cwd(); }
   const hash = createHash('md5').update(root).digest('hex').slice(0, 12);
-  const dir = join(process.env.XDG_RUNTIME_DIR || join(homedir(), '.cache', 'oco'), `session-${hash}`);
+  const cacheRoot = process.env.XDG_RUNTIME_DIR
+    || (process.platform === 'win32'
+      ? join(process.env.LOCALAPPDATA || join(homedir(), 'AppData', 'Local'), 'oco')
+      : join(homedir(), '.cache', 'oco'));
+  const dir = join(cacheRoot, `session-${hash}`);
   try { mkdirSync(dir, { recursive: true }); if (lstatSync(dir).isSymbolicLink()) return join(tmpdir(), 'oco-fallback'); } catch {}
   return dir;
 }


### PR DESCRIPTION
## Summary
- Use `%LOCALAPPDATA%\oco` on Windows instead of `~/.cache/oco` (Linux/Mac convention)
- Fix cache path in all 8 hook files (plugin/ + .claude/) 
- Remove dead URL parsing code in `findProjectRoot`
- Bump v0.3.3

## Problem
Cache dir was hardcoded to `~/.cache/oco` — a Linux/Mac convention that doesn't match Windows standards. On Windows, the correct location is `%LOCALAPPDATA%` (`C:\Users\<user>\AppData\Local`).

## Test plan
- [x] Verified on Windows: resolves to `C:\Users\Hokli\AppData\Local\oco`
- [ ] Verify on macOS: should resolve to `~/.cache/oco`
- [ ] Verify on Linux: should resolve to `~/.cache/oco` (or `$XDG_RUNTIME_DIR` if set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)