### PR TITLE
chore: bump v0.5.0 — docs, versions, architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.5.0] — 2026-03-26
+
+### Added
+- **Effort-level routing** — `EffortLevel` (Low/Medium/High) maps to Claude Code `--effort` flag; `LlmRouter.route_step()` returns `RoutingDecision` (model + effort) with role heuristics and budget-aware downgrade (#52)
+- **Claude Code `--bare` optimization** — 14% faster subprocess startup, `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB` and `CLAUDE_STREAM_IDLE_TIMEOUT_MS` env var support (#52)
+- **HTTP hook endpoints** — `/api/v1/hooks/{post-tool,task-completed,file-changed,post-compact,stop}` for Claude Code v2.1.63+ event integration, with Bearer auth middleware and 64KB body limit (#53)
+- **Deferred tool schema** — `CapabilityRegistry.deferred_tool_names()`, `to_tool_schemas()`, `resolve_deferred_tool()` expose OCO capabilities as Claude Code deferred tools via ToolSearch, with bijective ID encoding and sanitized descriptions (#54)
+- **MCP elicitation types** — `ElicitationRequest`/`ElicitationResponse` for interactive orchestration decisions (replan, verify gate, ambiguity) via Claude Code MCP elicitation v2.1.76+ (#55)
+- **Agent Teams executor scaffold** — `AgentTeamsExecutor` maps PlanSteps to Claude Code Agent Teams with async lifecycle (`RwLock`), worktree isolation heuristic, typed errors, `TeammateStatus` state machine (#56)
+- **Benchmark suite** — `examples/benchmark-v0.5.jsonl` with 17 scenarios across 8 tiers (baseline, budget, effort routing, hooks, capabilities, elicitation, agent teams, integration)
+
+### Fixed
+- **Eval pipeline** — `run_with_plan()` now pushes `OrchestratorAction::Respond` with plan output content; flat loop enriches `Respond` action with LLM content before recording; `PlanningContext` uses session budget instead of complexity default; CLI writes full `ScenarioResult` instead of reduced `EvaluationMetrics` (#57)
+- **Zero-limit budget guards** — `max_retrievals: 0` or `max_verify_cycles: 0` no longer kills the entire session; only the specific action type is blocked (#57)
+
 ## [0.4.0] — 2026-03-26
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ```bash
 cargo build                              # Build all crates
-cargo test                               # Run full test suite (330+ tests)
+cargo test                               # Run full test suite (421+ tests)
 cargo run -p oco-dev-cli -- --help       # CLI help
 
 oco index ./path                         # Index a workspace
@@ -33,7 +33,7 @@ Polyglot monorepo: **Rust core** + **Python ML worker** + **TypeScript VS Code e
 
 | # | Crate | Role |
 |---|-------|------|
-| 1 | `shared-types` | Domain types: Session, Action, Observation, Budget, Context, VerificationState, WorkingMemory, RepoProfile, **ExecutionPlan**, **CapabilityRegistry**, **TeamCoordinator**, OrchestrationEvent |
+| 1 | `shared-types` | Domain types: Session, Action, Observation, Budget, Context, VerificationState, WorkingMemory, RepoProfile, **ExecutionPlan**, **CapabilityRegistry**, **TeamCoordinator**, OrchestrationEvent, **ElicitationRequest**, **EffortLevel** |
 | 2 | `shared-proto` | Protobuf definitions (gRPC IPC) |
 | 3 | `policy-engine` | Deterministic action selection, budget enforcement, task classification |
 | 4 | `code-intel` | Tree-sitter parser (regex fallback), symbol indexer |
@@ -43,8 +43,8 @@ Polyglot monorepo: **Rust core** + **Python ML worker** + **TypeScript VS Code e
 | 8 | `telemetry` | Tracing init, decision trace collector, event recording |
 | 9 | `context-engine` | Context assembly, dedup, compression, staleness decay, category budgets, **step-scoped filtering** |
 | 10 | **`planner`** | **Task decomposition: DirectPlanner (Trivial/Low) + LlmPlanner (Medium+) → ExecutionPlan DAG** |
-| 11 | `orchestrator-core` | State machine, action loop, **GraphRunner (DAG execution)**, **LlmRouter (multi-model)**, LLM providers, runtime, eval runner, repo profiles |
-| 12 | `mcp-server` | Axum HTTP + MCP server, session management |
+| 11 | `orchestrator-core` | State machine, action loop, **GraphRunner (DAG execution)**, **LlmRouter (multi-model + effort)**, **AgentTeamsExecutor**, LLM providers, runtime, eval runner, repo profiles |
+| 12 | `mcp-server` | Axum HTTP + MCP server, session management, **HTTP hook endpoints** (Claude Code v2.1.63+) |
 | 13 | `dev-cli` | CLI binary (index, search, run, serve, eval, doctor, runs) — event-driven UI with Terminal/JSONL/Quiet renderers |
 | — | `architecture-tests` | Architecture fitness tests — enforces crate dependency DAG, layer violations, foundation isolation |
 
@@ -69,7 +69,8 @@ User Request → Classifier → Trivial/Low: flat loop (unchanged)
 - `ExecutionPlan` — DAG with `ready_steps()`, `parallel_groups()`, `critical_path_length()`, `validate()`, `validate_semantic()`
 - `PlanStep` — node with `AgentRole`, `StepExecution` (Inline/Subagent/Teammate/McpTool), `verify_after`
 - `EffortLevel` — Low/Medium/High, maps to Claude Code `--effort` flag
-- `CapabilityRegistry` — unified catalog of tools/MCP/agents/skills/LLMs, `query()`, `best_for()`, `sanitize_for_prompt()`
+- `CapabilityRegistry` — unified catalog of tools/MCP/agents/skills/LLMs, `query()`, `best_for()`, `sanitize_for_prompt()`, `deferred_tool_names()`, `resolve_deferred_tool()`
+- `ElicitationRequest` — MCP elicitation dialogs for replan/verify-gate/ambiguity decisions (v2.1.76+)
 - `TeamCoordinator` — spawns members (plan-scoped), shared task list, teardown
 - `SharedTaskList` — claimable/claim(ownership)/complete(ownership)/force_complete
 - `TeamCommunication` — HubSpoke (subagents) / Mesh (Agent Teams) / Pipeline (Factory)
@@ -78,6 +79,9 @@ User Request → Classifier → Trivial/Low: flat loop (unchanged)
 - `planner/` — `DirectPlanner` (no LLM) + `LlmPlanner` (structured JSON output, dep name→UUID, team generation, replan)
 - `orchestrator-core/graph_runner.rs` — `GraphRunner` with parallel execution (tokio::spawn), verify gates, budget pre-reservation, no-progress guard, JoinError→Failed
 - `orchestrator-core/llm_router.rs` — `LlmRouter` per-step model + effort selection (`RoutingDecision`), role heuristic + budget downgrade
+- `orchestrator-core/agent_teams.rs` — `AgentTeamsExecutor` maps PlanSteps to Claude Code Agent Teams (worktree isolation, async lifecycle, typed errors)
+- `mcp-server/hooks.rs` — HTTP hook handlers (PostToolUse, TaskCompleted, FileChanged, PostCompact, Stop) with Bearer auth + body limit
+- `shared-types/elicitation.rs` — `ElicitationRequest`/`ElicitationResponse` for interactive MCP decisions
 - `context-engine/step_scope.rs` — `StepContextBuilder` with dependency outputs, error context (Manus pattern), shared memory
 
 ### Python (`py/`)
@@ -131,16 +135,18 @@ cargo test                               # Full suite
 ```
 
 ```bash
-cargo test                               # All tests (368+)
-cargo test -p oco-shared-types           # 94 tests — domain types, verification, memory, profiles, plan DAG, capabilities, team, topology
-cargo test -p oco-policy-engine          # 30 tests — classifier, selector, budget, gates
-cargo test -p oco-context-engine         # 24 tests — assembler, dedup, compression, staleness, step-scoped context
-cargo test -p oco-code-intel             # 16 tests — parser, indexer, language detection
-cargo test -p oco-retrieval              #  9 tests — FTS5, vector, hybrid ranking
-cargo test -p oco-telemetry              #  5 tests — event recording, JSONL export
-cargo test -p oco-planner               # 34 tests — direct planner, LLM planner, prompt gen, team generation, retry, edge cases
-cargo test -p oco-orchestrator-core      # 40 tests — eval, integration, loop runner, graph runner, LLM router, effort routing, cancellation
-cargo test -p oco-architecture-tests     #  4 tests — dependency DAG, layer violations, foundation isolation, coverage
+cargo test                               # All tests (421+)
+cargo test -p oco-shared-types           # 121 tests — domain types, verification, memory, profiles, plan DAG, capabilities, team, topology, elicitation, effort level
+cargo test -p oco-policy-engine          #  67 tests — classifier, selector, budget, gates, zero-limit budgets
+cargo test -p oco-context-engine         #  24 tests — assembler, dedup, compression, staleness, step-scoped context
+cargo test -p oco-code-intel             #  29 tests — parser, indexer, language detection
+cargo test -p oco-retrieval              #   9 tests — FTS5, vector, hybrid ranking
+cargo test -p oco-telemetry              #  13 tests — event recording, JSONL export, hook telemetry
+cargo test -p oco-planner               #  36 tests — direct planner, LLM planner, prompt gen, team generation, retry, edge cases
+cargo test -p oco-orchestrator-core      #  62 tests — eval, integration, loop runner, graph runner, LLM router, effort routing, agent teams, cancellation
+cargo test -p oco-mcp-server             #  14 tests — MCP protocol, HTTP hooks (auth, validation, lifecycle), session management
+cargo test -p oco-verifier               #  32 tests — test/build/lint/typecheck runners, auto-detection
+cargo test -p oco-architecture-tests     #   4 tests — dependency DAG, layer violations, foundation isolation, coverage
 ```
 
 ## LLM Providers
@@ -199,9 +205,9 @@ oco/
 │   ├── dev-cli/                  # CLI binary
 │   └── vscode-extension/         # VS Code extension
 ├── crates/                       # 13 Rust crates (see table above)
-│   ├── shared-types/             # Domain types + ExecutionPlan + CapabilityRegistry + Team
-│   ├── planner/                  # NEW — DirectPlanner + LlmPlanner
-│   ├── orchestrator-core/        # State machine + GraphRunner + LlmRouter
+│   ├── shared-types/             # Domain types + ExecutionPlan + CapabilityRegistry + Team + Elicitation + EffortLevel
+│   ├── planner/                  # DirectPlanner + LlmPlanner
+│   ├── orchestrator-core/        # State machine + GraphRunner + LlmRouter + AgentTeamsExecutor
 │   ├── context-engine/           # Context assembly + StepContextBuilder
 │   ├── policy-engine/            # Action selection + classification
 │   ├── code-intel/               # Tree-sitter parsing
@@ -209,7 +215,7 @@ oco/
 │   ├── tool-runtime/             # Shell/file executors
 │   ├── verifier/                 # Test/build/lint runners
 │   ├── telemetry/                # Tracing + events
-│   ├── mcp-server/               # HTTP + MCP server
+│   ├── mcp-server/               # HTTP + MCP server + Claude Code hook endpoints
 │   ├── shared-proto/             # Protobuf defs
 │   ├── architecture-tests/       # Architecture fitness tests (DAG enforcement)
 │   └── ...

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/open-context-orchestrator/oco"

--- a/README.md
+++ b/README.md
@@ -58,26 +58,31 @@ Request → Classifier → Trivial/Low: flat action loop
                          ├── Verify gates after implementation steps
                          ├── Replan on failure (max 3 attempts, budget pre-check)
                          ├── Multi-model routing (opus/sonnet/haiku per step)
+                         ├── Effort-level routing (low/medium/high per step)
                          ├── Agent Teams (Mesh/HubSpoke/Pipeline topologies)
+                         ├── HTTP hooks for Claude Code event integration
+                         ├── MCP elicitation for interactive decisions
                          └── Cooperative cancellation + per-step budget limits
 ```
 
-### Rust Crates (13)
+### Rust Crates (15)
 
 | Crate | Role |
 |-------|------|
-| `shared-types` | Domain types, ExecutionPlan DAG, CapabilityRegistry, TeamCoordinator |
-| `policy-engine` | Deterministic action selection, budget enforcement |
+| `shared-types` | Domain types, ExecutionPlan DAG, CapabilityRegistry, TeamCoordinator, ElicitationRequest, EffortLevel |
+| `shared-proto` | Protobuf definitions (gRPC IPC) |
+| `policy-engine` | Deterministic action selection, budget enforcement, zero-limit guards |
 | `code-intel` | Tree-sitter parser, symbol indexer |
 | `retrieval` | SQLite FTS5, vector search, hybrid RRF ranking |
 | `context-engine` | Context assembly, dedup, step-scoped filtering |
 | `planner` | DirectPlanner (trivial) + LlmPlanner (Medium+ DAG generation) |
-| `orchestrator-core` | GraphRunner (DAG execution), LlmRouter (multi-model) |
+| `orchestrator-core` | GraphRunner (DAG execution), LlmRouter (multi-model + effort), AgentTeamsExecutor |
 | `tool-runtime` | Shell/file executors |
 | `verifier` | Test/build/lint/typecheck runners |
 | `telemetry` | Tracing, event recording |
-| `mcp-server` | Axum HTTP + MCP server |
+| `mcp-server` | Axum HTTP + MCP server, Claude Code HTTP hook endpoints |
 | `dev-cli` | CLI binary with Terminal/JSONL/Quiet renderers |
+| `architecture-tests` | Crate dependency DAG enforcement, layer violation detection |
 
 ## Key Principles
 
@@ -89,7 +94,9 @@ Request → Classifier → Trivial/Low: flat action loop
 - **Bounded** — explicit token, time, and tool-call budgets with per-step cancellation and step count limits
 - **Deterministic policy** — no LLM calls for routing decisions
 - **Multi-model routing** — opus for architecture, sonnet for implementation, haiku for exploration
+- **Effort-level routing** — automatic `--effort` selection per step role, budget-aware downgrade
 - **Agent Teams native** — Mesh, HubSpoke, Pipeline topologies with runtime enforcement
+- **Interactive decisions** — MCP elicitation for replan confirmation, architecture choices, verify gate failures
 - **Event-driven UI** — core emits structured events, CLI renders via pluggable renderers
 
 ## Stack
@@ -124,7 +131,7 @@ cd oco
 # Build all Rust crates
 cargo build
 
-# Run the test suite (358+ tests)
+# Run the test suite (421+ tests)
 cargo test
 
 # Run the CLI
@@ -170,6 +177,7 @@ Runtime config in `oco.toml`. See [`examples/oco.toml`](examples/oco.toml) for a
 
 | Provider | Config | Requirements |
 |----------|--------|--------------|
+| `claude-code` | `provider = "claude-code"` **(default)** | `claude` CLI on PATH |
 | `stub` | `provider = "stub"` | None |
 | `anthropic` | `provider = "anthropic"` | `ANTHROPIC_API_KEY` env var |
 | `ollama` | `provider = "ollama"` | Local Ollama at `localhost:11434` |

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "oco-vscode",
   "displayName": "Open Context Orchestrator",
   "description": "Intelligent orchestration middleware for coding assistants",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "oco",
   "license": "Apache-2.0",
   "engines": {

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -9,65 +9,58 @@
                     └──────────────┬──────────────────────┘
                                    │ HTTP/JSON
                     ┌──────────────▼──────────────────────┐
-                    │          MCP Server (Axum)           │
-                    │   ┌─────────────────────────────┐   │
-                    │   │     Orchestrator Core        │   │
-                    │   │  ┌───────────────────────┐  │   │
-                    │   │  │    Policy Engine       │  │   │
-                    │   │  │  - Task Classifier     │  │   │
-                    │   │  │  - Action Selector     │  │   │
-                    │   │  │  - Budget Enforcer     │  │   │
-                    │   │  │  - Write Gates         │  │   │
-                    │   │  │  - Knowledge Estimator │  │   │
-                    │   │  └───────────────────────┘  │   │
-                    │   │  ┌───────────────────────┐  │   │
-                    │   │  │   Context Engine       │  │   │
-                    │   │  │  - Assembler           │  │   │
-                    │   │  │  - Compressor          │  │   │
-                    │   │  │  - Deduplicator        │  │   │
-                    │   │  │  - Token Estimator     │  │   │
-                    │   │  └───────────────────────┘  │   │
-                    │   │  ┌───────────────────────┐  │   │
-                    │   │  │   Tool Runtime         │  │   │
-                    │   │  │  - Registry            │  │   │
-                    │   │  │  - Shell Executor      │  │   │
-                    │   │  │  - File Executor       │  │   │
-                    │   │  │  - Normalizer          │  │   │
-                    │   │  └───────────────────────┘  │   │
-                    │   └─────────────────────────────┘   │
-                    │                                     │
-                    │  ┌──────────┐  ┌─────────────────┐  │
-                    │  │ Code     │  │   Retrieval      │  │
-                    │  │ Intel    │  │  - FTS5 Index    │  │
-                    │  │ (TS)    │  │  - Vector Backend │  │
-                    │  └──────────┘  │  - Hybrid        │  │
-                    │                └─────────────────┘  │
-                    │  ┌──────────┐  ┌─────────────────┐  │
-                    │  │ Verifier │  │   Telemetry      │  │
-                    │  │ - Tests  │  │  - Traces        │  │
-                    │  │ - Build  │  │  - Metrics       │  │
-                    │  │ - Lint   │  │  - tracing init  │  │
-                    │  └──────────┘  └─────────────────┘  │
+                    │     MCP Server (Axum)                │
+                    │  ┌─────────────────────────────────┐│
+                    │  │ HTTP Hook Endpoints (v2.1.63+)  ││
+                    │  │ post-tool, task-completed,       ││
+                    │  │ file-changed, post-compact, stop ││
+                    │  └─────────────────────────────────┘│
+┌──────────────┐    │  ┌─────────────────────────────────┐│    ┌─────────────┐
+│  Claude Code │◄──►│  │      Orchestrator Core          ││◄──►│  LLM APIs   │
+│  (MCP/Hooks) │    │  │  ┌──────────┐  ┌────────────┐  ││    │ (any model) │
+└──────────────┘    │  │  │ Policy   │  │  Planner   │  ││    └─────────────┘
+                    │  │  │ Engine   │  │ Direct/LLM │  ││
+                    │  │  │ Classify │  ├────────────┤  ││
+                    │  │  │ Select   │  │ GraphRunner│  ││
+                    │  │  │ Budget   │  │ (parallel) │  ││
+                    │  │  │ Gates    │  ├────────────┤  ││
+                    │  │  └──────────┘  │ LlmRouter  │  ││
+                    │  │                │ model+effort│  ││
+                    │  │  ┌──────────┐  ├────────────┤  ││
+                    │  │  │ Context  │  │AgentTeams  │  ││
+                    │  │  │ Engine   │  │ Executor   │  ││
+                    │  │  │ +StepCtx │  └────────────┘  ││
+                    │  │  └──────────┘                   ││
+                    │  │  ┌──────────┐  ┌────────────┐  ││
+                    │  │  │ Tool RT  │  │ Code Intel │  ││
+                    │  │  │ Shell/FS │  │ Tree-sitter│  ││
+                    │  │  └──────────┘  └────────────┘  ││
+                    │  │  ┌──────────┐  ┌────────────┐  ││
+                    │  │  │ Verifier │  │ Retrieval  │  ││    ┌─────────────┐
+                    │  │  │ test/lint│  │ FTS5+Vec   │  ││◄──►│  SQLite     │
+                    │  │  └──────────┘  └────────────┘  ││    └─────────────┘
+                    │  │  ┌──────────┐                   ││
+                    │  │  │Telemetry │                   ││
+                    │  │  │ traces   │                   ││
+                    │  │  └──────────┘                   ││
+                    │  └─────────────────────────────────┘│
                     └──────────────┬──────────────────────┘
-                                   │ HTTP/JSON
+                                   │ HTTP/JSON (optional)
                     ┌──────────────▼──────────────────────┐
                     │         ML Worker (Python)           │
                     │  - Sentence Transformers (embed)     │
                     │  - Cross-Encoder (rerank)            │
-                    │  - Fallback heuristics               │
-                    └──────────────┬──────────────────────┘
-                                   │
-                    ┌──────────────▼──────────────────────┐
-                    │           SQLite + FTS5              │
                     └─────────────────────────────────────┘
 ```
 
 ## Crate Dependency Graph
 
 ```
-shared-types ◄── policy-engine
-     ▲            ▲
-     │            │
+shared-types ◄── shared-proto
+     ▲
+     │
+     ├── policy-engine
+     │
      ├── code-intel ◄── context-engine
      │                      ▲
      ├── retrieval ◄────────┘
@@ -78,21 +71,45 @@ shared-types ◄── policy-engine
      │
      ├── telemetry
      │
+     ├── planner (DirectPlanner + LlmPlanner)
+     │
      └── orchestrator-core (depends on all above)
+              │  ├── GraphRunner (DAG execution)
+              │  ├── LlmRouter (model + effort routing)
+              │  ├── AgentTeamsExecutor (Claude Code Agent Teams)
+              │  └── Eval runner (scenario benchmarking)
               ▲
               │
-              ├── mcp-server
+              ├── mcp-server (HTTP + MCP + hook endpoints)
               │
-              └── dev-cli
+              └── dev-cli (CLI binary)
+
+architecture-tests (fitness tests, no runtime dependency)
 ```
 
-## Data Flow
+## Orchestration Flow
 
-1. User sends request via VS Code extension or dev-cli
+### Trivial/Low tasks — flat action loop
+1. User sends request via VS Code extension, Claude Code, or dev-cli
 2. MCP server creates a session and starts the orchestration loop
-3. Policy engine classifies complexity and selects first action
+3. Policy engine classifies complexity (Trivial/Low) and selects action
 4. Action is executed (retrieve/tool/verify/respond)
 5. Result is normalized into a structured Observation
 6. State is updated, decision trace is recorded
 7. Loop continues until stop condition (complete/budget/error)
-8. Final state and traces are returned to the client
+
+### Medium+ tasks — emergent plan engine
+1. Classifier detects Medium/High/Critical complexity
+2. Planner generates ExecutionPlan DAG (DirectPlanner or LlmPlanner)
+3. GraphRunner executes steps in parallel where possible
+4. LlmRouter selects model (opus/sonnet/haiku) and effort (low/medium/high) per step
+5. AgentTeamsExecutor maps steps to Claude Code Agent Teams (worktree isolation)
+6. Verify gates run after implementation steps
+7. On failure: replan (max 3 attempts, budget pre-check)
+8. Combined outputs are surfaced as Respond action
+
+### Claude Code integration
+- **HTTP hooks** receive real-time events (tool use, file changes, session stop)
+- **MCP elicitation** enables interactive decisions (replan confirmation, architecture choices)
+- **Deferred tool schemas** expose OCO capabilities via ToolSearch
+- **Agent Teams** enable parallel step execution with worktree isolation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oco-claude-plugin",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "OCO Claude Code plugin — safety hooks, skills, agents, and MCP tools for any project",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- **Version bump**: 0.4.0 → 0.5.0 across Cargo.toml, package.json, vscode extension
- **CLAUDE.md**: test counts 368 → 421, new modules (agent_teams, hooks, elicitation, deferred schemas), updated crate descriptions
- **README.md**: crate table 12 → 15 (added shared-proto, architecture-tests), test count 358 → 421, new features (effort routing, elicitation, hooks)
- **CHANGELOG.md**: full v0.5.0 entry covering PRs #52–#57
- **docs/architecture/overview.md**: complete rewrite — Planner, GraphRunner, AgentTeamsExecutor, LlmRouter, HTTP hooks, orchestration flow

## Test plan

- [x] `cargo build` — compiles as v0.5.0
- [x] `cargo test` — 421 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)