### PR TITLE
fix: clarify plugin-only vs full mode in DX messaging

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -32,10 +32,10 @@ npx oco-claude-plugin repair             # restore missing files
 
 | Mode | Condition | What works |
 |---|---|---|
-| **full** | hooks + settings + bridge + `oco` binary | Everything: hooks, skills, agents, MCP tools |
-| **plugin** | hooks + settings + bridge, no `oco` binary | Hooks, skills, agents. MCP tools return task packets. |
-| **degraded** | Some components missing | Partial functionality |
-| **broken** | Settings or hooks missing | Plugin will not load |
+| **full** | plugin + `oco` binary on PATH | Everything: hooks, skills, agents, all MCP tools |
+| **plugin-only** | plugin installed, no `oco` binary | Hooks, skills, agents, MCP verify_patch/working_memory. Other MCP tools return fallback results. |
+| **incomplete** | Some plugin files missing | Partial functionality — run `repair` to restore |
+| **broken** | Settings or hooks missing | Plugin will not load — run `install --force` |
 
 Run `doctor` to see your current mode.
 

--- a/.claude/mcp/bridge.cjs
+++ b/.claude/mcp/bridge.cjs
@@ -257,10 +257,10 @@ async function searchCodebase(id, args) {
 
   if (result.error) {
     return respondStructured(id, {
-      summary: "OCO backend unavailable",
+      summary: "oco runtime not installed — indexed search unavailable",
       evidence: [],
-      risks: ["Search results may be incomplete without OCO indexing"],
-      next_step: "Use standard search tools (Grep, Glob) as fallback",
+      risks: ["The oco binary is not on PATH. Install from OCO source: cd /path/to/oco && cargo install --path apps/dev-cli"],
+      next_step: "Use Grep/Glob for text search as fallback",
       confidence: 0.0,
     });
   }
@@ -324,6 +324,14 @@ async function traceError(id, args) {
 
   const deepestFrame = frames[frames.length - 1];
   const matchedFiles = results.filter((r) => r.matches && (Array.isArray(r.matches) ? r.matches.length > 0 : true));
+  const allSearchesFailed = results.length === 0 && fileSet.length > 0;
+
+  const risks = [];
+  if (allSearchesFailed) {
+    risks.push("oco runtime not installed — codebase matching unavailable. Use Grep to locate frames manually.");
+  } else if (matchedFiles.length === 0) {
+    risks.push("No stack frames matched local files — error may originate in dependencies");
+  }
 
   return respondStructured(id, {
     summary: `Parsed ${frames.length} frame(s) across ${fileSet.length} file(s). ${matchedFiles.length} matched in codebase.`,
@@ -331,13 +339,11 @@ async function traceError(id, args) {
       { parsed_frames: frames },
       { codebase_matches: results },
     ],
-    risks: matchedFiles.length === 0
-      ? ["No stack frames matched local files — error may originate in dependencies"]
-      : [],
+    risks,
     next_step: deepestFrame
       ? `Inspect ${deepestFrame.file}:${deepestFrame.line} — deepest application frame`
       : "Review the stack trace manually",
-    confidence: matchedFiles.length > 0 ? 0.7 : 0.3,
+    confidence: matchedFiles.length > 0 ? 0.7 : allSearchesFailed ? 0.2 : 0.3,
   });
 }
 
@@ -404,9 +410,9 @@ async function collectFindings(id, args) {
 
   if (result.error) {
     return respondStructured(id, {
-      summary: "No OCO session data available",
+      summary: "oco runtime not installed — session traces unavailable",
       evidence: [],
-      risks: ["Session trace unavailable — investigation state unknown"],
+      risks: ["The oco binary is not on PATH. Install from OCO source: cd /path/to/oco && cargo install --path apps/dev-cli"],
       next_step: "Use standard investigation tools to gather evidence",
       confidence: 0.0,
     });
@@ -549,7 +555,7 @@ async function beginTask(id, args) {
   if (result.error) {
     // OCO binary unavailable — return a task packet for manual execution
     return respondStructured(id, {
-      summary: "OCO runtime unavailable — returning task packet for manual execution",
+      summary: "oco runtime not installed — returning task plan for manual execution",
       evidence: [{
         task_packet: {
           intent: args.task,
@@ -563,8 +569,8 @@ async function beginTask(id, args) {
           ],
         },
       }],
-      risks: ["Running without OCO orchestration — no automatic verification or replanning"],
-      next_step: "Execute the task packet steps manually using standard tools",
+      risks: ["The oco binary is not on PATH. Install from OCO source: cd /path/to/oco && cargo install --path apps/dev-cli"],
+      next_step: "Execute the task steps manually using standard tools",
       confidence: 0.3,
     });
   }

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ npx oco-claude-plugin uninstall        # clean removal
 - **3 agents** — `codebase-investigator`, `patch-verifier`, `refactor-reviewer`
 - **MCP tools** — composite codebase search, error tracing, patch verification, findings collection
 
-Works immediately with Node.js only. No API key required. Enhanced features available when the `oco` binary is installed.
+**Plugin-only mode** (Node.js only, no build required):
+hooks, skills, agents, and basic MCP tools work immediately. No API key required.
+
+**Full mode** (requires [Rust toolchain](https://rustup.rs) + OCO source repo):
+install the `oco` binary (`cargo install --path apps/dev-cli`) for indexed search,
+stack trace mapping, and task delegation via MCP.
 
 ## Architecture
 

--- a/cli.mjs
+++ b/cli.mjs
@@ -22,6 +22,41 @@ const MANIFEST_FILE = '.oco-install-manifest.json';
 const DROPIN_FILE = 'managed-settings.d/50-oco.json';
 const VERSION = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8')).version;
 
+const MODE_DESCRIPTIONS = {
+  full: 'plugin + runtime — all features active',
+  'plugin-only': 'plugin installed, runtime not found — hooks, skills, agents work; MCP tools return fallback results',
+  incomplete: 'some plugin files missing — run: npx oco-claude-plugin repair',
+  broken: 'settings or hooks missing — plugin will not load, run: npx oco-claude-plugin install --force',
+};
+
+function resolveMode({ settingsOk, allHooksOk, bridgeOk, ocoAvailable }) {
+  if (!settingsOk || !allHooksOk) return 'broken';
+  if (!bridgeOk) return 'incomplete';
+  if (ocoAvailable) return 'full';
+  return 'plugin-only';
+}
+
+function getOcoVersion() {
+  try {
+    const res = spawnSync('oco', ['--version'], {
+      encoding: 'utf8', timeout: 3000, windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const match = (res.stdout || '').trim().match(/\b(\d+\.\d+\.\d+)/);
+    return match ? match[1] : null;
+  } catch { return null; }
+}
+
+function checkOcoUsable() {
+  try {
+    const res = spawnSync('oco', ['--help'], {
+      encoding: 'utf8', timeout: 5000, windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return res.status === 0;
+  } catch { return false; }
+}
+
 // --- CLI Argument Parsing ---
 
 const [,, command, ...args] = process.argv;
@@ -145,8 +180,8 @@ async function install() {
   console.log(`\n  Installed: ${copied} file(s), ${skipped} skipped.`);
 
   // 5. Post-install diagnostic — show real mode, not just files copied
-  console.log('\n  Post-install check');
   const ocoAvailable = commandExists('oco');
+  const ocoVersion = ocoAvailable ? getOcoVersion() : null;
   const allHooksOk = ['hooks/pre-tool-use.mjs', 'hooks/post-tool-use.mjs',
     'hooks/stop.mjs', 'hooks/user-prompt-submit.cjs',
   ].every(f => existsSync(join(targetDir, f)));
@@ -154,10 +189,18 @@ async function install() {
   const settingsOk = existsSync(join(targetDir, DROPIN_FILE)) || existsSync(settingsPath);
 
   const check = (ok, msg) => console.log(`    ${ok ? '✓' : '✗'} ${msg}`);
+
+  console.log('\n  Plugin layer');
   check(allHooksOk, '4/4 hooks');
   check(settingsOk, useDropin ? 'managed-settings.d/50-oco.json' : 'settings.json');
   check(bridgeOk, 'MCP bridge');
-  check(ocoAvailable, `oco binary${ocoAvailable ? '' : ' (optional — MCP tools degraded)'}`);
+
+  console.log('\n  Runtime layer');
+  if (ocoAvailable) {
+    check(true, `oco binary found${ocoVersion ? ` (v${ocoVersion})` : ''}`);
+  } else {
+    check(false, 'oco binary not found');
+  }
 
   // Dual install warning
   const otherDir = isGlobal ? resolveTargetSafe('project') : resolveTargetSafe('global');
@@ -169,22 +212,22 @@ async function install() {
   }
 
   // Mode
-  let mode;
-  if (!settingsOk || !allHooksOk) mode = 'broken';
-  else if (!bridgeOk) mode = 'degraded';
-  else if (ocoAvailable) mode = 'full';
-  else mode = 'plugin';
+  const mode = resolveMode({ settingsOk, allHooksOk, bridgeOk, ocoAvailable });
+  console.log(`\n  Mode: ${mode} (${MODE_DESCRIPTIONS[mode]})`);
 
-  const modeDesc = {
-    full: 'hooks + skills + MCP tools active',
-    plugin: 'hooks + skills active, MCP tools degraded without oco binary',
-    degraded: 'partial — some components missing',
-    broken: 'settings or hooks missing — plugin will not load',
-  };
-  console.log(`\n  Mode: ${mode} (${modeDesc[mode]})`);
+  if (mode === 'plugin-only') {
+    console.log(`
+  What works now:
+    • Safety hooks (destructive command blocking, verification enforcement)
+    • 5 skills (/oco-inspect-repo-area, /oco-verify-fix, etc.)
+    • 3 agents (codebase-investigator, patch-verifier, refactor-reviewer)
+    • MCP verify_patch and working_memory (no binary needed)
 
-  if (!ocoAvailable) {
-    console.log(`\n  For full MCP support: cargo install --path apps/dev-cli`);
+  What needs the oco binary:
+    • MCP search_codebase, trace_error, begin_task, collect_findings
+
+  To install the runtime (requires Rust toolchain and access to OCO source):
+    cd /path/to/oco && cargo install --path apps/dev-cli`);
   }
   console.log(`\n  Open Claude Code in this project to activate.\n`);
 }
@@ -303,7 +346,16 @@ function status() {
   if (missing.length > 0) {
     console.log(`  Missing:    ${missing.join(', ')}`);
   }
-  console.log(`  OCO binary: ${ocoAvailable ? 'found' : 'not found (optional)'}`);
+  const ocoVersion = ocoAvailable ? getOcoVersion() : null;
+  console.log(`  Runtime:    ${ocoAvailable ? `found${ocoVersion ? ` (v${ocoVersion})` : ''}` : 'not installed'}`);
+
+  const allHooksOk = ['hooks/pre-tool-use.mjs', 'hooks/post-tool-use.mjs',
+    'hooks/stop.mjs', 'hooks/user-prompt-submit.cjs',
+  ].every(f => existsSync(join(targetDir, f)));
+  const settingsOk = existsSync(join(targetDir, DROPIN_FILE)) || existsSync(join(targetDir, 'settings.json'));
+  const bridgeOk = existsSync(join(targetDir, 'mcp/bridge.cjs'));
+  const mode = resolveMode({ settingsOk, allHooksOk, bridgeOk, ocoAvailable });
+  console.log(`  Mode:       ${mode}`);
   console.log();
 }
 
@@ -371,8 +423,8 @@ function doctor() {
   else if (existsSync(settingsPath)) warn('settings.json (legacy mode, prefer managed-settings.d)');
   else fail('No settings found (hooks will not load)');
 
-  // --- Files ---
-  console.log('\n  Components');
+  // --- Plugin layer ---
+  console.log('\n  Plugin layer');
   const expectedHooks = [
     'hooks/pre-tool-use.mjs', 'hooks/post-tool-use.mjs',
     'hooks/stop.mjs', 'hooks/user-prompt-submit.cjs',
@@ -406,14 +458,29 @@ function doctor() {
   if (existsSync(join(targetDir, 'mcp/bridge.cjs'))) ok('MCP bridge');
   else warn('MCP bridge missing (mcp/bridge.cjs)');
 
-  // --- Optional: oco binary ---
-  const ocoAvailable = commandExists('oco');
-  if (ocoAvailable) ok('oco binary found');
-  else warn('oco binary not found (optional — MCP tools degraded)');
-
   // --- Version match ---
   if (manifest.version !== VERSION) {
     warn(`Installed v${manifest.version}, available v${VERSION} — run: npx oco-claude-plugin install --force`);
+  }
+
+  // --- Runtime layer ---
+  console.log('\n  Runtime layer');
+  const ocoAvailable = commandExists('oco');
+  if (ocoAvailable) {
+    const ocoVersion = getOcoVersion();
+    const ocoUsable = checkOcoUsable();
+    if (ocoUsable) {
+      ok(`oco binary found${ocoVersion ? ` (v${ocoVersion})` : ''} — functional`);
+    } else {
+      warn(`oco binary found${ocoVersion ? ` (v${ocoVersion})` : ''} but returned an error`);
+      console.log('      Run: oco --help  to diagnose');
+    }
+  } else {
+    warn('oco binary not found');
+    console.log('      MCP tools search_codebase, trace_error, begin_task, collect_findings');
+    console.log('      will return fallback results without the runtime.');
+    console.log('      To install (requires Rust toolchain + OCO source repo):');
+    console.log('        cd /path/to/oco && cargo install --path apps/dev-cli');
   }
 
   // --- Conflicts ---
@@ -431,34 +498,18 @@ function doctor() {
   const settingsOk = existsSync(dropinPath) || existsSync(settingsPath);
   const bridgeOk = existsSync(join(targetDir, 'mcp/bridge.cjs'));
 
-  let mode;
-  if (!settingsOk || !allHooksOk) mode = 'broken';
-  else if (!bridgeOk || issues.errors > 0) mode = 'degraded';
-  else if (ocoAvailable) mode = 'full';
-  else mode = 'plugin';
+  const mode = resolveMode({ settingsOk, allHooksOk, bridgeOk, ocoAvailable });
+  console.log(`\n  Mode: ${mode} (${MODE_DESCRIPTIONS[mode]})`);
 
-  const modeDescriptions = {
-    full: 'hooks + skills + MCP tools active',
-    plugin: 'hooks + skills active, MCP tools degraded without oco binary',
-    degraded: 'partial — some components missing',
-    broken: 'settings or hooks missing — plugin will not load',
-  };
-
-  console.log(`\n  Mode: ${mode} (${modeDescriptions[mode]})`);
-
-  if (mode === 'broken') {
+  if (mode === 'broken' || mode === 'incomplete') {
     console.log(`\n  Run: npx oco-claude-plugin repair`);
-  } else if (mode === 'degraded') {
-    console.log(`\n  Run: npx oco-claude-plugin repair`);
-  } else if (!ocoAvailable) {
-    console.log(`\n  For full MCP support: cargo install --path apps/dev-cli`);
   }
 
   console.log();
 
-  // Exit codes: 0 = ok, 1 = warnings/degraded, 2 = broken
+  // Exit codes: 0 = ok, 1 = warnings/incomplete, 2 = broken
   if (mode === 'broken') return 2;
-  if (issues.warnings > 0 || mode === 'degraded') return 1;
+  if (issues.warnings > 0 || mode === 'incomplete') return 1;
   return 0;
 }
 

--- a/oco-plugin/docs/README.md
+++ b/oco-plugin/docs/README.md
@@ -16,32 +16,44 @@ OCO is a local coprocessor that makes Claude Code smarter about your codebase:
 ### Prerequisites
 
 - [Claude Code](https://claude.ai/claude-code) installed
-- Rust toolchain (for building OCO backend)
+- Node.js >= 18
 
-### Install
+### Install the plugin
 
 ```bash
-# Build OCO backend
-cd /path/to/supertools
-cargo build --release
-
-# Add oco binary to PATH
-export PATH="$PATH:/path/to/supertools/target/release"
-
-# Install plugin (copy to your project or link globally)
-cp -r oco-plugin/.claude/ ~/.claude/  # Global install
-# OR
-cp -r oco-plugin/.claude/ .claude/    # Project-level install
+npx oco-claude-plugin install          # project-level
+npx oco-claude-plugin install --global # all projects
 ```
 
-### Verify
+This installs hooks, skills, agents, and the MCP bridge into `.claude/`.
+**It does not install the OCO runtime binary.**
+
+### What works immediately (plugin-only mode)
+
+- Safety hooks (destructive command blocking, verification enforcement)
+- 5 structured skills (`/oco-inspect-repo-area`, `/oco-verify-fix`, etc.)
+- 3 specialized agents (`codebase-investigator`, `patch-verifier`, `refactor-reviewer`)
+- MCP `verify_patch` (runs cargo/npm directly, no binary needed)
+- MCP `working_memory` (local file persistence, no binary needed)
+
+### Optional: install the runtime for full mode
+
+The OCO runtime enables indexed codebase search, stack trace mapping,
+task delegation, and session trace collection via MCP tools.
 
 ```bash
-# Check OCO binary is available
-oco --help
+# Requires Rust toolchain (https://rustup.rs) and access to the OCO source repo
+cd /path/to/oco
+cargo install --path apps/dev-cli
 
-# Start Claude Code — hooks and skills are now active
-claude
+# Verify
+oco --version
+```
+
+### Check installation
+
+```bash
+npx oco-claude-plugin doctor
 ```
 
 ## Usage
@@ -109,14 +121,22 @@ Edit `.claude/settings.json` to customize:
 | `OCO_BIN` | `oco` | Path to OCO binary |
 | `OCO_WORKSPACE` | `$PWD` | Default workspace root |
 
-## Graceful Degradation
+## Plugin-only vs Full Mode
 
-All plugin components degrade gracefully if the OCO backend is unavailable:
+| Feature | Plugin-only | Full (with runtime) |
+|---------|:-----------:|:-------------------:|
+| Safety hooks | ✓ | ✓ |
+| Skills (/oco-*) | ✓ | ✓ |
+| Agents (@codebase-investigator, etc.) | ✓ | ✓ |
+| MCP verify_patch | ✓ | ✓ |
+| MCP working_memory | ✓ | ✓ |
+| MCP search_codebase (indexed search) | fallback | ✓ |
+| MCP trace_error (stack mapping) | fallback | ✓ |
+| MCP begin_task (task delegation) | fallback | ✓ |
+| MCP collect_findings (session traces) | fallback | ✓ |
 
-- **Hooks**: Skip classification/gating, fall through silently
-- **Skills**: Work with standard Claude Code tools instead of OCO-backed search
-- **MCP tools**: Return empty results with a note to use standard tools
-- **Subagents**: Always work (they use standard Claude Code tools)
+**Fallback** means the tool returns a structured response explaining the runtime
+is not installed, with a suggestion to use standard Claude Code tools instead.
 
 ## Architecture
 

--- a/plugin/mcp/bridge.cjs
+++ b/plugin/mcp/bridge.cjs
@@ -257,10 +257,10 @@ async function searchCodebase(id, args) {
 
   if (result.error) {
     return respondStructured(id, {
-      summary: "OCO backend unavailable",
+      summary: "oco runtime not installed — indexed search unavailable",
       evidence: [],
-      risks: ["Search results may be incomplete without OCO indexing"],
-      next_step: "Use standard search tools (Grep, Glob) as fallback",
+      risks: ["The oco binary is not on PATH. Install from OCO source: cd /path/to/oco && cargo install --path apps/dev-cli"],
+      next_step: "Use Grep/Glob for text search as fallback",
       confidence: 0.0,
     });
   }
@@ -324,6 +324,14 @@ async function traceError(id, args) {
 
   const deepestFrame = frames[frames.length - 1];
   const matchedFiles = results.filter((r) => r.matches && (Array.isArray(r.matches) ? r.matches.length > 0 : true));
+  const allSearchesFailed = results.length === 0 && fileSet.length > 0;
+
+  const risks = [];
+  if (allSearchesFailed) {
+    risks.push("oco runtime not installed — codebase matching unavailable. Use Grep to locate frames manually.");
+  } else if (matchedFiles.length === 0) {
+    risks.push("No stack frames matched local files — error may originate in dependencies");
+  }
 
   return respondStructured(id, {
     summary: `Parsed ${frames.length} frame(s) across ${fileSet.length} file(s). ${matchedFiles.length} matched in codebase.`,
@@ -331,13 +339,11 @@ async function traceError(id, args) {
       { parsed_frames: frames },
       { codebase_matches: results },
     ],
-    risks: matchedFiles.length === 0
-      ? ["No stack frames matched local files — error may originate in dependencies"]
-      : [],
+    risks,
     next_step: deepestFrame
       ? `Inspect ${deepestFrame.file}:${deepestFrame.line} — deepest application frame`
       : "Review the stack trace manually",
-    confidence: matchedFiles.length > 0 ? 0.7 : 0.3,
+    confidence: matchedFiles.length > 0 ? 0.7 : allSearchesFailed ? 0.2 : 0.3,
   });
 }
 
@@ -404,9 +410,9 @@ async function collectFindings(id, args) {
 
   if (result.error) {
     return respondStructured(id, {
-      summary: "No OCO session data available",
+      summary: "oco runtime not installed — session traces unavailable",
       evidence: [],
-      risks: ["Session trace unavailable — investigation state unknown"],
+      risks: ["The oco binary is not on PATH. Install from OCO source: cd /path/to/oco && cargo install --path apps/dev-cli"],
       next_step: "Use standard investigation tools to gather evidence",
       confidence: 0.0,
     });
@@ -549,7 +555,7 @@ async function beginTask(id, args) {
   if (result.error) {
     // OCO binary unavailable — return a task packet for manual execution
     return respondStructured(id, {
-      summary: "OCO runtime unavailable — returning task packet for manual execution",
+      summary: "oco runtime not installed — returning task plan for manual execution",
       evidence: [{
         task_packet: {
           intent: args.task,
@@ -563,8 +569,8 @@ async function beginTask(id, args) {
           ],
         },
       }],
-      risks: ["Running without OCO orchestration — no automatic verification or replanning"],
-      next_step: "Execute the task packet steps manually using standard tools",
+      risks: ["The oco binary is not on PATH. Install from OCO source: cd /path/to/oco && cargo install --path apps/dev-cli"],
+      next_step: "Execute the task steps manually using standard tools",
       confidence: 0.3,
     });
   }


### PR DESCRIPTION
## Summary

- Rename operating modes: `plugin` → `plugin-only`, `degraded` → `incomplete`
- Separate "Plugin layer" / "Runtime layer" in `install` and `doctor` output
- MCP fallback messages now say "runtime not installed" with install command instead of opaque "backend unavailable"
- Docs updated to distinguish what works immediately vs what needs the `oco` binary

## Test plan

- [ ] Run `npx oco-claude-plugin doctor` with `oco` on PATH → mode `full`
- [ ] Run `npx oco-claude-plugin doctor` without `oco` on PATH → mode `plugin-only` with clear guidance
- [ ] Run `npx oco-claude-plugin install` without `oco` → post-install shows what works / what needs runtime
- [ ] Run `npx oco-claude-plugin status` → shows mode and runtime version
- [ ] Trigger MCP `search_codebase` without runtime → returns "runtime not installed" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)