### PR TITLE
chore: bump version to 0.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oco-claude-plugin",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "OCO Claude Code plugin — safety hooks, skills, agents, and MCP tools for any project",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release with DX improvements:
- `install` now writes `.mcp.json` → `claude mcp list` shows oco
- Clearer mode names: `plugin-only`, `incomplete`
- MCP health check in install/doctor output
- Explicit fallback messages when runtime is missing

## Test plan

- [ ] `npx oco-claude-plugin install --force` in any repo → full diagnostic output
- [ ] `claude mcp list` → oco connected

🤖 Generated with [Claude Code](https://claude.com/claude-code)