### PR TITLE
feat: dashboard v2 — Mission Control tactical UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ async-stream = "0.3"
 # Web / API
 axum = { version = "0.8", features = ["json", "ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "limit", "trace"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "limit", "trace"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/apps/dashboard/src/App.svelte
+++ b/apps/dashboard/src/App.svelte
@@ -2,33 +2,53 @@
   import './app.css'
   import { connectSSE, type SSEStatus } from './lib/sse'
   import type { DashboardEvent, BudgetSnapshot, StepRow } from './lib/types'
-  import EventLog from './lib/EventLog.svelte'
-  import StepTable from './lib/StepTable.svelte'
-  import BudgetGauge from './lib/BudgetGauge.svelte'
+  import MissionCard from './lib/MissionCard.svelte'
+  import MissionView from './lib/MissionView.svelte'
 
   let events = $state<DashboardEvent[]>([])
   let steps = $state<StepRow[]>([])
   let budget = $state<BudgetSnapshot | null>(null)
   let status = $state<SSEStatus>('closed')
   let replayId = $state('')
-  let runDir = $state('')
-  let speed = $state(1)
+  let speed = $state(10)
   let connected = $state(false)
+  let missionRequest = $state('')
 
-  async function createReplay() {
-    if (!runDir.trim()) return
+  type Run = {
+    id: string; request: string; complexity: string; steps: number
+    duration_ms: number; success: boolean; created_at: string; run_dir: string
+    tokens_used: number; tokens_max: number; status: string
+  }
+
+  let runs = $state<Run[]>([])
+  let loading = $state(true)
+  let statsTotal = $derived(runs.length)
+  let statsSuccess = $derived(runs.filter(r => r.success).length)
+  let statsFail = $derived(runs.filter(r => !r.success).length)
+  let statsTotalSteps = $derived(runs.reduce((a, r) => a + r.steps, 0))
+
+  $effect(() => { fetchRuns() })
+
+  async function fetchRuns() {
+    loading = true
+    try {
+      const res = await fetch('/api/v1/dashboard/runs?limit=50')
+      if (res.ok) runs = await res.json()
+    } catch {}
+    loading = false
+  }
+
+  async function selectRun(runDir: string) {
     const res = await fetch('/api/v1/dashboard/replays', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ run_dir: runDir, speed }),
     })
-    if (!res.ok) {
-      const err = await res.json()
-      alert(err.error || 'Failed to create replay')
-      return
-    }
+    if (!res.ok) { alert((await res.json()).error || 'Load failed'); return }
     const data = await res.json()
     replayId = data.replay_id
+    const run = runs.find(r => r.run_dir === runDir)
+    missionRequest = run?.request ?? ''
     connectToReplay(data.stream_url)
   }
 
@@ -36,9 +56,7 @@
 
   function connectToReplay(streamUrl: string) {
     client?.close()
-    events = []
-    steps = []
-    budget = null
+    events = []; steps = []; budget = null
     connected = true
     client = connectSSE(streamUrl)
     client.onStatus(s => { status = s })
@@ -49,49 +67,31 @@
     events = [...events, event]
     const kind = event.kind as Record<string, unknown>
     const type = kind.type as string
-
     switch (type) {
-      case 'plan_generated': {
-        const planSteps = (kind.steps as Array<Record<string, unknown>>) ?? []
-        steps = planSteps.map(s => ({
-          id: s.id as string,
-          name: s.name as string,
-          role: s.role as string,
-          status: 'pending' as const,
-          duration_ms: null,
-          tokens_used: null,
-          execution_mode: s.execution_mode as string,
-          verify_passed: null,
+      case 'plan_generated':
+        steps = ((kind.steps as Array<Record<string, unknown>>) ?? []).map(s => ({
+          id: s.id as string, name: s.name as string, role: s.role as string,
+          status: 'pending' as const, duration_ms: null, tokens_used: null,
+          execution_mode: s.execution_mode as string, verify_passed: null,
         }))
         break
-      }
-      case 'step_started': {
-        const id = kind.step_id as string
-        steps = steps.map(s => s.id === id ? { ...s, status: 'running' as const } : s)
+      case 'step_started':
+        steps = steps.map(s => s.id === (kind.step_id as string) ? { ...s, status: 'running' as const } : s)
         break
-      }
       case 'step_completed': {
         const id = kind.step_id as string
-        steps = steps.map(s => s.id === id ? {
-          ...s,
+        steps = steps.map(s => s.id === id ? { ...s,
           status: (kind.success ? 'passed' : 'failed') as StepRow['status'],
-          duration_ms: kind.duration_ms as number,
-          tokens_used: kind.tokens_used as number,
+          duration_ms: kind.duration_ms as number, tokens_used: kind.tokens_used as number,
         } : s)
         break
       }
-      case 'verify_gate_result': {
-        const id = kind.step_id as string
-        steps = steps.map(s => s.id === id ? {
-          ...s,
-          verify_passed: kind.overall_passed as boolean,
-        } : s)
+      case 'verify_gate_result':
+        steps = steps.map(s => s.id === (kind.step_id as string) ? { ...s, verify_passed: kind.overall_passed as boolean } : s)
         break
-      }
-      case 'progress':
-      case 'flat_step_completed': {
+      case 'progress': case 'flat_step_completed': {
         const snap = (kind.budget ?? kind.budget_snapshot) as BudgetSnapshot | undefined
-        if (snap && snap.tokens_used !== undefined) budget = snap
+        if (snap?.tokens_used !== undefined) budget = snap
         break
       }
     }
@@ -101,104 +101,77 @@
   async function resume() { await fetch(`/api/v1/dashboard/replays/${replayId}/resume`, { method: 'POST' }) }
   async function setSpeed(s: number) {
     speed = s
-    await fetch(`/api/v1/dashboard/replays/${replayId}/speed`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+    if (replayId) await fetch(`/api/v1/dashboard/replays/${replayId}/speed`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ speed: s }),
     })
   }
 
   function disconnect() {
     client?.close()
-    connected = false
-    status = 'closed'
-  }
-
-  const statusColors: Record<SSEStatus, string> = {
-    connecting: 'bg-warning',
-    connected: 'bg-success',
-    reconnecting: 'bg-warning',
-    closed: 'bg-text-dim',
+    connected = false; status = 'closed'
+    events = []; steps = []; budget = null; missionRequest = ''
+    fetchRuns()
   }
 </script>
 
-<div class="h-screen flex flex-col bg-surface text-text">
-  <header class="flex items-center justify-between px-4 py-2 border-b border-border bg-surface-2">
-    <div class="flex items-center gap-3">
-      <h1 class="text-sm font-semibold text-text-bright tracking-wide">OCO Dashboard</h1>
-      <span class="text-xs text-text-dim font-mono">v0.10.0</span>
-    </div>
-    <div class="flex items-center gap-2">
-      <span class="w-2 h-2 rounded-full {statusColors[status]}"></span>
-      <span class="text-xs text-text-dim">{status}</span>
-    </div>
-  </header>
-
-  {#if !connected}
-    <div class="flex-1 flex items-center justify-center">
-      <div class="bg-surface-2 border border-border rounded-xl p-6 w-full max-w-md">
-        <h2 class="text-lg font-semibold text-text-bright mb-4">Load a trace</h2>
-        <div class="space-y-3">
-          <div>
-            <label for="rundir" class="text-xs text-text-dim block mb-1">Run directory</label>
-            <input
-              id="rundir"
-              type="text"
-              bind:value={runDir}
-              placeholder=".oco/runs/abc123..."
-              class="w-full bg-surface-3 border border-border rounded-lg px-3 py-2 text-sm text-text outline-none focus:border-accent"
-            />
+{#if connected}
+  <MissionView
+    {events} {steps} {budget} request={missionRequest}
+    onDisconnect={disconnect} onPause={pause} onResume={resume} onSpeed={setSpeed} {speed} {status}
+  />
+{:else}
+  <div class="min-h-screen bg-surface scanlines">
+    <!-- Header -->
+    <header class="border-b border-border bg-surface-2">
+      <div class="max-w-5xl mx-auto px-6 py-3 flex items-center justify-between">
+        <div>
+          <div class="text-[10px] font-mono uppercase tracking-[0.2em] text-text-dim">Open Context Orchestrator</div>
+          <div class="text-sm font-semibold text-text-bright mt-0.5">Mission Control</div>
+        </div>
+        <div class="flex items-center gap-4">
+          <!-- Aggregate stats -->
+          <div class="flex items-center gap-3 text-[10px] font-mono">
+            <div><span class="text-text-dim">RUNS</span> <span class="text-text-bright">{statsTotal}</span></div>
+            <div><span class="text-text-dim">PASS</span> <span class="text-success">{statsSuccess}</span></div>
+            <div><span class="text-text-dim">FAIL</span> <span class="text-error">{statsFail}</span></div>
+            <div><span class="text-text-dim">STEPS</span> <span class="text-text-bright">{statsTotalSteps}</span></div>
           </div>
-          <div>
-            <label for="speed" class="text-xs text-text-dim block mb-1">Speed: {speed}x</label>
-            <input id="speed" type="range" min="0.5" max="20" step="0.5" bind:value={speed} class="w-full accent-accent" />
+          <div class="w-px h-6 bg-border"></div>
+          <!-- Speed selector -->
+          <div class="flex items-center gap-1">
+            <span class="text-[10px] font-mono text-text-dim uppercase">Speed</span>
+            {#each [1, 5, 10, 50] as s}
+              <button
+                onclick={() => { speed = s }}
+                class="text-[10px] font-mono px-1.5 py-0.5 {speed === s ? 'bg-accent text-white' : 'text-text-dim bg-surface-3 hover:bg-border-bright'} transition-colors"
+              >{s}x</button>
+            {/each}
           </div>
-          <button
-            onclick={createReplay}
-            disabled={!runDir.trim()}
-            class="w-full bg-accent hover:bg-accent/80 disabled:opacity-40 text-white font-medium py-2 rounded-lg text-sm transition-colors"
-          >Start replay</button>
         </div>
       </div>
-    </div>
-  {:else}
-    <div class="flex-1 flex overflow-hidden">
-      <div class="w-1/2 border-r border-border flex flex-col">
-        <div class="px-3 py-2 border-b border-border bg-surface-2">
-          <span class="text-xs font-semibold text-text-bright">Event Log</span>
-        </div>
-        <div class="flex-1 overflow-hidden">
-          <EventLog {events} />
-        </div>
-      </div>
+    </header>
 
-      <div class="w-1/2 flex flex-col">
-        <div class="flex items-center gap-2 px-3 py-2 border-b border-border bg-surface-2">
-          <button onclick={pause} class="text-xs px-2 py-1 rounded bg-surface-3 hover:bg-border text-text-dim">Pause</button>
-          <button onclick={resume} class="text-xs px-2 py-1 rounded bg-surface-3 hover:bg-border text-text-dim">Resume</button>
-          {#each [1, 2, 5, 10, 50] as s}
-            <button
-              onclick={() => setSpeed(s)}
-              class="text-xs px-2 py-1 rounded {speed === s ? 'bg-accent text-white' : 'bg-surface-3 text-text-dim hover:bg-border'}"
-            >{s}x</button>
+    <!-- Mission grid -->
+    <main class="max-w-5xl mx-auto px-6 py-6">
+      {#if loading}
+        <div class="text-center py-16 text-[10px] font-mono text-text-dim uppercase tracking-widest">
+          Scanning archives...
+        </div>
+      {:else if runs.length === 0}
+        <div class="text-center py-16 border border-border bg-surface-2">
+          <div class="text-xs text-text-dim mb-2">No missions recorded</div>
+          <div class="text-[10px] font-mono text-text-dim">
+            Execute <span class="text-accent">oco run "your task"</span> to begin
+          </div>
+        </div>
+      {:else}
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+          {#each runs as run (run.id)}
+            <MissionCard {run} onSelect={selectRun} />
           {/each}
-          <div class="flex-1"></div>
-          <button onclick={disconnect} class="text-xs px-2 py-1 rounded bg-error/20 text-error hover:bg-error/30">Disconnect</button>
         </div>
-
-        <div class="px-3 py-3 border-b border-border">
-          <div class="text-xs font-semibold text-text-bright mb-2">Budget</div>
-          <BudgetGauge {budget} />
-        </div>
-
-        <div class="flex-1 overflow-y-auto">
-          <div class="px-3 py-2 border-b border-border bg-surface-2">
-            <span class="text-xs font-semibold text-text-bright">Plan Steps</span>
-            <span class="text-xs text-text-dim ml-2">{steps.filter(s => s.status === 'passed').length}/{steps.length}</span>
-          </div>
-          <StepTable {steps} />
-        </div>
-      </div>
-    </div>
-  {/if}
-</div>
+      {/if}
+    </main>
+  </div>
+{/if}

--- a/apps/dashboard/src/app.css
+++ b/apps/dashboard/src/app.css
@@ -3,28 +3,64 @@
 @theme {
   --font-mono: ui-monospace, 'Cascadia Code', 'JetBrains Mono', Consolas, monospace;
   --font-sans: system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --color-surface: #0f1117;
-  --color-surface-2: #161822;
-  --color-surface-3: #1e2030;
-  --color-border: #2e3148;
-  --color-text: #c8cad8;
-  --color-text-dim: #6b6f8a;
-  --color-text-bright: #e8eaf4;
-  --color-accent: #7c6ef0;
-  --color-accent-dim: rgba(124, 110, 240, 0.15);
-  --color-success: #4ade80;
-  --color-error: #f87171;
-  --color-warning: #fbbf24;
-  --color-info: #60a5fa;
-  --color-running: #818cf8;
+
+  /* XCOM-inspired dark tactical palette */
+  --color-surface: #0a0c10;
+  --color-surface-2: #0f1218;
+  --color-surface-3: #161b24;
+  --color-border: #1e2634;
+  --color-border-bright: #2a3546;
+  --color-text: #8892a4;
+  --color-text-dim: #505a6e;
+  --color-text-bright: #d0d6e0;
+  --color-text-white: #eef0f4;
+  --color-accent: #3b82f6;
+  --color-accent-dim: rgba(59, 130, 246, 0.12);
+  --color-success: #22c55e;
+  --color-success-dim: rgba(34, 197, 94, 0.12);
+  --color-error: #ef4444;
+  --color-error-dim: rgba(239, 68, 68, 0.12);
+  --color-warning: #eab308;
+  --color-warning-dim: rgba(234, 179, 8, 0.12);
+  --color-running: #6366f1;
+  --color-running-dim: rgba(99, 102, 241, 0.12);
+  --color-pending: #374151;
 }
 
 html {
   background: var(--color-surface);
   color: var(--color-text);
   font-family: var(--font-sans);
+  font-size: 14px;
 }
 
-body {
-  margin: 0;
+body { margin: 0; }
+
+/* Tactical scanline overlay */
+.scanlines {
+  background-image: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.03) 2px,
+    rgba(0, 0, 0, 0.03) 4px
+  );
+}
+
+/* Status pip indicator */
+.pip {
+  width: 6px;
+  height: 6px;
+  border-radius: 1px;
+}
+
+.pip-success { background: var(--color-success); box-shadow: 0 0 4px var(--color-success); }
+.pip-error { background: var(--color-error); box-shadow: 0 0 4px var(--color-error); }
+.pip-running { background: var(--color-running); box-shadow: 0 0 4px var(--color-running); animation: pulse 1.5s ease-in-out infinite; }
+.pip-pending { background: var(--color-pending); }
+.pip-warning { background: var(--color-warning); box-shadow: 0 0 4px var(--color-warning); }
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
 }

--- a/apps/dashboard/src/lib/BudgetGauge.svelte
+++ b/apps/dashboard/src/lib/BudgetGauge.svelte
@@ -8,7 +8,7 @@
     return total > 0 ? Math.round((used / total) * 100) : 0
   }
 
-  function barColor(p: number): string {
+  function barClass(p: number): string {
     if (p >= 90) return 'bg-error'
     if (p >= 75) return 'bg-warning'
     return 'bg-accent'
@@ -19,41 +19,45 @@
 </script>
 
 {#if budget}
-  <div class="grid grid-cols-2 gap-3">
-    <div class="rounded-lg bg-surface-3 p-3">
-      <div class="flex justify-between text-xs text-text-dim mb-1">
-        <span>Tokens</span>
-        <span>{budget.tokens_used.toLocaleString()} / {(budget.tokens_used + budget.tokens_remaining).toLocaleString()}</span>
+  <div class="space-y-2">
+    <!-- Tokens -->
+    <div>
+      <div class="flex justify-between text-[10px] font-mono mb-0.5">
+        <span class="text-text-dim uppercase tracking-wider">Tokens</span>
+        <span class="text-text">{budget.tokens_used.toLocaleString()} / {(budget.tokens_used + budget.tokens_remaining).toLocaleString()}</span>
       </div>
-      <div class="h-2 rounded-full bg-surface overflow-hidden">
-        <div class="h-full rounded-full transition-all duration-300 {barColor(tokenPct)}" style="width: {tokenPct}%"></div>
-      </div>
-    </div>
-
-    <div class="rounded-lg bg-surface-3 p-3">
-      <div class="flex justify-between text-xs text-text-dim mb-1">
-        <span>Tool calls</span>
-        <span>{budget.tool_calls_used} / {budget.tool_calls_used + budget.tool_calls_remaining}</span>
-      </div>
-      <div class="h-2 rounded-full bg-surface overflow-hidden">
-        <div class="h-full rounded-full transition-all duration-300 {barColor(toolPct)}" style="width: {toolPct}%"></div>
+      <div class="h-1.5 bg-surface overflow-hidden">
+        <div class="h-full transition-all duration-500 {barClass(tokenPct)}" style="width: {tokenPct}%"></div>
       </div>
     </div>
 
-    <div class="rounded-lg bg-surface-3 p-3">
-      <div class="flex justify-between text-xs text-text-dim mb-1">
-        <span>Retrievals</span>
-        <span>{budget.retrievals_used}</span>
+    <!-- Tool calls -->
+    <div>
+      <div class="flex justify-between text-[10px] font-mono mb-0.5">
+        <span class="text-text-dim uppercase tracking-wider">Actions</span>
+        <span class="text-text">{budget.tool_calls_used} / {budget.tool_calls_used + budget.tool_calls_remaining}</span>
+      </div>
+      <div class="h-1.5 bg-surface overflow-hidden">
+        <div class="h-full transition-all duration-500 {barClass(toolPct)}" style="width: {toolPct}%"></div>
       </div>
     </div>
 
-    <div class="rounded-lg bg-surface-3 p-3">
-      <div class="flex justify-between text-xs text-text-dim mb-1">
-        <span>Verify cycles</span>
-        <span>{budget.verify_cycles_used}</span>
+    <!-- Counters row -->
+    <div class="flex gap-4 pt-1">
+      <div class="text-[10px] font-mono">
+        <span class="text-text-dim uppercase tracking-wider">Recon</span>
+        <span class="text-text ml-1.5">{budget.retrievals_used}</span>
+      </div>
+      <div class="text-[10px] font-mono">
+        <span class="text-text-dim uppercase tracking-wider">Verify</span>
+        <span class="text-text ml-1.5">{budget.verify_cycles_used}</span>
+      </div>
+      <div class="text-[10px] font-mono">
+        <span class="text-text-dim uppercase tracking-wider">Elapsed</span>
+        <span class="text-text ml-1.5">{budget.elapsed_secs}s</span>
       </div>
     </div>
   </div>
 {:else}
-  <div class="text-text-dim text-sm">No budget data yet</div>
+  <div class="text-[10px] font-mono text-text-dim uppercase tracking-wider">Awaiting data</div>
 {/if}

--- a/apps/dashboard/src/lib/MissionCard.svelte
+++ b/apps/dashboard/src/lib/MissionCard.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+  let { run, onSelect }: {
+    run: { id: string; request: string; complexity: string; steps: number; duration_ms: number; success: boolean; created_at: string; run_dir: string; tokens_used: number; tokens_max: number }
+    onSelect: (runDir: string) => void
+  } = $props()
+
+  const complexityRank: Record<string, number> = {
+    Trivial: 1, Low: 2, Medium: 3, High: 4, Critical: 5,
+  }
+
+  function formatDuration(ms: number): string {
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+    return `${Math.floor(ms / 60000)}m ${Math.floor((ms % 60000) / 1000)}s`
+  }
+
+  function timeAgo(dateStr: string): string {
+    if (!dateStr) return ''
+    const diff = Date.now() - new Date(dateStr).getTime()
+    const mins = Math.floor(diff / 60000)
+    if (mins < 1) return 'just now'
+    if (mins < 60) return `${mins}m ago`
+    const hrs = Math.floor(mins / 60)
+    if (hrs < 24) return `${hrs}h ago`
+    return `${Math.floor(hrs / 24)}d ago`
+  }
+
+  let rank = $derived(complexityRank[run.complexity] ?? 0)
+</script>
+
+<button
+  onclick={() => onSelect(run.run_dir)}
+  class="w-full text-left bg-surface-2 border border-border hover:border-border-bright transition-all group cursor-pointer"
+>
+  <!-- Status bar top -->
+  <div class="h-0.5 {run.success ? 'bg-success' : 'bg-error'}"></div>
+
+  <div class="p-3">
+    <!-- Top row: status + time -->
+    <div class="flex items-center justify-between mb-2">
+      <div class="flex items-center gap-2">
+        <div class="pip {run.success ? 'pip-success' : 'pip-error'}"></div>
+        <span class="text-[10px] font-mono uppercase tracking-wider {run.success ? 'text-success' : 'text-error'}">
+          {run.success ? 'COMPLETE' : 'FAILED'}
+        </span>
+      </div>
+      <span class="text-[10px] font-mono text-text-dim">{timeAgo(run.created_at)}</span>
+    </div>
+
+    <!-- Mission name -->
+    <p class="text-xs text-text-bright font-medium mb-3 line-clamp-2 leading-relaxed group-hover:text-text-white transition-colors">
+      {run.request || '—'}
+    </p>
+
+    <!-- Stats row -->
+    <div class="flex items-center gap-4 text-[10px] font-mono text-text-dim">
+      <div class="flex items-center gap-1.5">
+        <span class="text-text-dim">STEPS</span>
+        <span class="text-text">{run.steps}</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span class="text-text-dim">TIME</span>
+        <span class="text-text">{formatDuration(run.duration_ms)}</span>
+      </div>
+      <div class="flex items-center gap-1.5">
+        <span class="text-text-dim">RANK</span>
+        <!-- Complexity pips -->
+        <div class="flex gap-0.5">
+          {#each Array(5) as _, i}
+            <div class="w-1.5 h-3 {i < rank ? (rank >= 4 ? 'bg-warning' : 'bg-accent') : 'bg-surface'}"></div>
+          {/each}
+        </div>
+      </div>
+    </div>
+  </div>
+</button>

--- a/apps/dashboard/src/lib/MissionView.svelte
+++ b/apps/dashboard/src/lib/MissionView.svelte
@@ -1,0 +1,205 @@
+<script lang="ts">
+  import type { DashboardEvent, BudgetSnapshot, StepRow } from './types'
+  import BudgetGauge from './BudgetGauge.svelte'
+  import StepTable from './StepTable.svelte'
+
+  let {
+    events, steps, budget, request,
+    onDisconnect, onPause, onResume, onSpeed, speed, status,
+  }: {
+    events: DashboardEvent[]; steps: StepRow[]; budget: BudgetSnapshot | null
+    request: string; onDisconnect: () => void; onPause: () => void
+    onResume: () => void; onSpeed: (s: number) => void; speed: number; status: string
+  } = $props()
+
+  let filter = $state('')
+  let autoScroll = $state(true)
+  let logEl: HTMLDivElement | undefined = $state()
+
+  // Tactical narrative — no emojis, military-style log
+  function narrative(kind: Record<string, unknown>): string {
+    const type = kind.type as string
+    switch (type) {
+      case 'flat_step_completed': {
+        const action = kind.action_type as string
+        const ms = kind.duration_ms as number
+        if (action.startsWith('retrieve')) return `RECON — scanned codebase [${ms}ms]`
+        if (action.startsWith('tool:')) return `EXEC — ${action.replace('tool:', '')} [${ms}ms]`
+        if (action.startsWith('verify:')) return `CHECK — ${action.replace('verify:', '')} [${ms}ms]`
+        if (action === 'respond') return 'REPORT — response formulated'
+        if (action.startsWith('stop:')) return 'END — mission terminated'
+        return `${action.toUpperCase()} [${ms}ms]`
+      }
+      case 'step_started': return `DEPLOY — ${kind.step_name} [${(kind.role as string).toUpperCase()}]`
+      case 'step_completed': {
+        const ok = kind.success as boolean
+        return `${ok ? 'DONE' : 'FAIL'} — ${kind.step_name} [${kind.duration_ms}ms / ${(kind.tokens_used as number).toLocaleString()} tok]`
+      }
+      case 'plan_generated': return `PLAN — ${kind.step_count} objectives, strategy: ${kind.strategy}`
+      case 'progress': return `SITREP — ${kind.completed}/${kind.total} objectives complete`
+      case 'verify_gate_result': {
+        const ok = kind.overall_passed as boolean
+        return `GATE ${ok ? 'CLEAR' : 'BLOCKED'} — ${kind.step_name}${kind.replan_triggered ? ' > REPLAN' : ''}`
+      }
+      case 'replan_triggered': return `REPLAN #${kind.attempt}/${kind.max_attempts} — +${kind.steps_added} -${kind.steps_removed} objectives`
+      case 'budget_warning': return `WARNING — ${kind.resource} at ${Math.round((kind.utilization as number) * 100)}%`
+      case 'run_started': return `INIT — ${kind.model} / ${kind.provider}`
+      case 'run_stopped': return `DEBRIEF — ${kind.total_steps} steps, ${(kind.total_tokens as number).toLocaleString()} tokens`
+      default: return type.toUpperCase()
+    }
+  }
+
+  function logClass(kind: Record<string, unknown>): string {
+    const type = kind.type as string
+    switch (type) {
+      case 'step_completed': return (kind.success as boolean) ? 'text-success' : 'text-error'
+      case 'verify_gate_result': return (kind.overall_passed as boolean) ? 'text-success' : 'text-error'
+      case 'replan_triggered': return 'text-warning'
+      case 'budget_warning': return 'text-warning'
+      case 'run_stopped': return 'text-accent'
+      case 'flat_step_completed': {
+        const action = kind.action_type as string
+        if (action.startsWith('verify:')) return 'text-accent'
+        return 'text-text'
+      }
+      default: return 'text-text'
+    }
+  }
+
+  function pipClass(kind: Record<string, unknown>): string {
+    const type = kind.type as string
+    switch (type) {
+      case 'step_completed': return (kind.success as boolean) ? 'pip-success' : 'pip-error'
+      case 'verify_gate_result': return (kind.overall_passed as boolean) ? 'pip-success' : 'pip-error'
+      case 'replan_triggered': return 'pip-warning'
+      case 'budget_warning': return 'pip-warning'
+      case 'run_stopped': return 'pip-success'
+      case 'step_started': return 'pip-running'
+      default: return 'pip-pending'
+    }
+  }
+
+  let filtered = $derived.by(() => {
+    if (!filter) return events
+    const lower = filter.toLowerCase()
+    return events.filter(e => {
+      const kind = e.kind as Record<string, unknown>
+      return narrative(kind).toLowerCase().includes(lower)
+    })
+  })
+
+  let completedSteps = $derived(steps.filter(s => s.status === 'passed' || s.status === 'failed').length)
+  let totalSteps = $derived(steps.length)
+  let progressPct = $derived(totalSteps > 0 ? Math.round((completedSteps / totalSteps) * 100) : (events.length > 0 ? Math.min(events.length * 11, 100) : 0))
+  let isFinished = $derived(events.some(e => (e.kind as Record<string, unknown>).type === 'run_stopped'))
+  let missionStatus = $derived(isFinished ? 'COMPLETE' : status === 'connected' ? 'IN PROGRESS' : 'CONNECTING')
+  let missionPip = $derived(isFinished ? 'pip-success' : status === 'connected' ? 'pip-running' : 'pip-warning')
+
+  $effect(() => {
+    if (autoScroll && logEl && filtered.length > 0) {
+      logEl.scrollTop = logEl.scrollHeight
+    }
+  })
+</script>
+
+<div class="h-screen flex flex-col bg-surface scanlines">
+  <!-- Mission header bar -->
+  <header class="border-b border-border bg-surface-2">
+    <!-- Top info row -->
+    <div class="flex items-center justify-between px-4 py-2 border-b border-border">
+      <div class="flex items-center gap-3">
+        <div class="pip {missionPip}"></div>
+        <span class="text-[10px] font-mono uppercase tracking-widest {isFinished ? 'text-success' : 'text-running'}">{missionStatus}</span>
+        <span class="text-border-bright">|</span>
+        <span class="text-xs text-text-bright">{request || 'Mission'}</span>
+      </div>
+      <div class="flex items-center gap-1">
+        <button onclick={onPause} class="text-[10px] font-mono px-2 py-1 text-text-dim hover:text-text bg-surface-3 hover:bg-border-bright transition-colors uppercase tracking-wider">Pause</button>
+        <button onclick={onResume} class="text-[10px] font-mono px-2 py-1 text-text-dim hover:text-text bg-surface-3 hover:bg-border-bright transition-colors uppercase tracking-wider">Play</button>
+        <div class="w-px h-4 bg-border mx-1"></div>
+        {#each [1, 5, 10, 50] as s}
+          <button
+            onclick={() => onSpeed(s)}
+            class="text-[10px] font-mono px-1.5 py-1 transition-colors uppercase {speed === s ? 'bg-accent text-white' : 'text-text-dim hover:text-text bg-surface-3 hover:bg-border-bright'}"
+          >{s}x</button>
+        {/each}
+        <div class="w-px h-4 bg-border mx-1"></div>
+        <button onclick={onDisconnect} class="text-[10px] font-mono px-2 py-1 text-error/70 hover:text-error bg-surface-3 hover:bg-error-dim transition-colors uppercase tracking-wider">Abort</button>
+      </div>
+    </div>
+
+    <!-- Progress bar -->
+    <div class="h-1 bg-surface">
+      <div
+        class="h-full transition-all duration-700 {isFinished ? 'bg-success' : 'bg-accent'}"
+        style="width: {progressPct}%"
+      ></div>
+    </div>
+  </header>
+
+  <!-- Main content -->
+  <div class="flex-1 flex overflow-hidden">
+    <!-- Left panel: Tactical log -->
+    <div class="w-3/5 border-r border-border flex flex-col">
+      <!-- Log header -->
+      <div class="flex items-center gap-2 px-3 py-1.5 border-b border-border bg-surface-2">
+        <span class="text-[10px] font-mono text-text-dim uppercase tracking-widest">Operations log</span>
+        <div class="flex-1"></div>
+        <input
+          type="text"
+          bind:value={filter}
+          placeholder="filter"
+          class="w-32 bg-surface-3 border border-border text-[10px] font-mono text-text px-2 py-0.5 outline-none focus:border-accent placeholder:text-text-dim"
+        />
+        <label class="flex items-center gap-1 text-[10px] font-mono text-text-dim cursor-pointer">
+          <input type="checkbox" bind:checked={autoScroll} class="accent-accent w-3 h-3" />
+          follow
+        </label>
+        <span class="text-[10px] font-mono text-text-dim">{events.length}</span>
+      </div>
+
+      <!-- Log entries -->
+      <div bind:this={logEl} class="flex-1 overflow-y-auto">
+        {#each filtered as event (event.seq)}
+          {@const kind = event.kind as Record<string, unknown>}
+          <div class="flex items-center gap-2 px-3 py-1 border-b border-border/30 hover:bg-surface-3/30 transition-colors">
+            <span class="text-[10px] font-mono text-text-dim w-6 text-right shrink-0">{event.seq}</span>
+            <div class="pip {pipClass(kind)} shrink-0"></div>
+            <span class="text-[10px] font-mono text-text-dim w-16 shrink-0">
+              {new Date(event.ts).toLocaleTimeString('en', { hour12: false })}
+            </span>
+            <span class="text-xs font-mono {logClass(kind)} truncate">{narrative(kind)}</span>
+          </div>
+        {/each}
+
+        {#if isFinished}
+          <div class="mx-3 my-2 py-2 px-3 border border-success/30 bg-success-dim">
+            <span class="text-[10px] font-mono uppercase tracking-widest text-success">Mission complete</span>
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <!-- Right panel: Status -->
+    <div class="w-2/5 flex flex-col overflow-y-auto bg-surface-2/50">
+      <!-- Resources section -->
+      <div class="p-3 border-b border-border">
+        <div class="text-[10px] font-mono text-text-dim uppercase tracking-widest mb-2">Resources</div>
+        <BudgetGauge {budget} />
+      </div>
+
+      <!-- Objectives section (plan steps) -->
+      <div class="flex-1 flex flex-col">
+        <div class="flex items-center justify-between px-3 py-1.5 border-b border-border">
+          <span class="text-[10px] font-mono text-text-dim uppercase tracking-widest">Objectives</span>
+          {#if totalSteps > 0}
+            <span class="text-[10px] font-mono text-text">{completedSteps}/{totalSteps}</span>
+          {/if}
+        </div>
+        <div class="flex-1 overflow-y-auto">
+          <StepTable {steps} />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/apps/dashboard/src/lib/StepTable.svelte
+++ b/apps/dashboard/src/lib/StepTable.svelte
@@ -3,14 +3,21 @@
 
   let { steps }: { steps: StepRow[] } = $props()
 
-  const statusIcon: Record<StepRow['status'], string> = {
-    pending: '○',
-    running: '◉',
-    passed: '✓',
-    failed: '✗',
+  const statusLabel: Record<StepRow['status'], string> = {
+    pending: 'STANDBY',
+    running: 'ACTIVE',
+    passed: 'DONE',
+    failed: 'FAIL',
   }
 
-  const statusColor: Record<StepRow['status'], string> = {
+  const statusPip: Record<StepRow['status'], string> = {
+    pending: 'pip-pending',
+    running: 'pip-running',
+    passed: 'pip-success',
+    failed: 'pip-error',
+  }
+
+  const statusText: Record<StepRow['status'], string> = {
     pending: 'text-text-dim',
     running: 'text-running',
     passed: 'text-success',
@@ -19,54 +26,55 @@
 </script>
 
 {#if steps.length > 0}
-  <div class="overflow-x-auto">
-    <table class="w-full text-sm">
-      <thead>
-        <tr class="border-b border-border text-text-dim text-left">
-          <th class="py-2 px-3 font-normal w-8"></th>
-          <th class="py-2 px-3 font-normal">Step</th>
-          <th class="py-2 px-3 font-normal">Role</th>
-          <th class="py-2 px-3 font-normal">Mode</th>
-          <th class="py-2 px-3 font-normal text-right">Duration</th>
-          <th class="py-2 px-3 font-normal text-right">Tokens</th>
-          <th class="py-2 px-3 font-normal text-center">Verify</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each steps as step (step.id)}
-          <tr class="border-b border-border/50 hover:bg-surface-3/50 transition-colors">
-            <td class="py-2 px-3 {statusColor[step.status]} font-mono">
-              {statusIcon[step.status]}
-            </td>
-            <td class="py-2 px-3 text-text-bright font-medium truncate max-w-48">
-              {step.name}
-            </td>
-            <td class="py-2 px-3 text-text-dim">{step.role}</td>
-            <td class="py-2 px-3">
-              <span class="text-xs px-1.5 py-0.5 rounded bg-accent-dim text-accent">
-                {step.execution_mode}
-              </span>
-            </td>
-            <td class="py-2 px-3 text-right font-mono text-text-dim">
-              {step.duration_ms != null ? `${step.duration_ms}ms` : '—'}
-            </td>
-            <td class="py-2 px-3 text-right font-mono text-text-dim">
-              {step.tokens_used != null ? step.tokens_used.toLocaleString() : '—'}
-            </td>
-            <td class="py-2 px-3 text-center">
-              {#if step.verify_passed === true}
-                <span class="text-success">✓</span>
-              {:else if step.verify_passed === false}
-                <span class="text-error">✗</span>
-              {:else}
-                <span class="text-text-dim">—</span>
-              {/if}
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+  <div class="divide-y divide-border">
+    {#each steps as step, i (step.id)}
+      <div class="flex items-center gap-3 px-3 py-2 hover:bg-surface-3/30 transition-colors {step.status === 'running' ? 'bg-running-dim' : ''}">
+        <!-- Index -->
+        <span class="text-[10px] font-mono text-text-dim w-4 text-right shrink-0">{i + 1}</span>
+
+        <!-- Status pip -->
+        <div class="pip {statusPip[step.status]} shrink-0"></div>
+
+        <!-- Name + role -->
+        <div class="flex-1 min-w-0">
+          <div class="text-xs text-text-bright truncate">{step.name}</div>
+          <div class="text-[10px] font-mono text-text-dim flex items-center gap-2">
+            <span class="uppercase">{step.role}</span>
+            <span class="text-border-bright">|</span>
+            <span>{step.execution_mode}</span>
+          </div>
+        </div>
+
+        <!-- Status label -->
+        <span class="text-[10px] font-mono uppercase tracking-wider {statusText[step.status]} w-14 text-right shrink-0">
+          {statusLabel[step.status]}
+        </span>
+
+        <!-- Duration -->
+        <span class="text-[10px] font-mono text-text-dim w-14 text-right shrink-0">
+          {step.duration_ms != null ? `${step.duration_ms}ms` : '—'}
+        </span>
+
+        <!-- Tokens -->
+        <span class="text-[10px] font-mono text-text-dim w-12 text-right shrink-0">
+          {step.tokens_used != null ? `${step.tokens_used}` : '—'}
+        </span>
+
+        <!-- Verify -->
+        <div class="w-4 shrink-0 flex justify-center">
+          {#if step.verify_passed === true}
+            <div class="pip pip-success"></div>
+          {:else if step.verify_passed === false}
+            <div class="pip pip-error"></div>
+          {:else}
+            <div class="pip pip-pending"></div>
+          {/if}
+        </div>
+      </div>
+    {/each}
   </div>
 {:else}
-  <div class="text-text-dim text-sm py-4 text-center">No plan steps yet</div>
+  <div class="text-[10px] font-mono text-text-dim uppercase tracking-wider text-center py-6">
+    No plan — flat execution
+  </div>
 {/if}

--- a/apps/dashboard/vite.config.ts
+++ b/apps/dashboard/vite.config.ts
@@ -4,6 +4,7 @@ import tailwindcss from '@tailwindcss/vite'
 
 export default defineConfig({
   plugins: [tailwindcss(), svelte()],
+  base: '/dashboard/',
   server: {
     port: 5173,
     proxy: {

--- a/apps/dev-cli/Cargo.toml
+++ b/apps/dev-cli/Cargo.toml
@@ -17,6 +17,7 @@ oco-mcp-server = { workspace = true }
 oco-policy-engine = { workspace = true }
 oco-verifier = { workspace = true }
 tokio = { workspace = true }
+axum = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }

--- a/apps/dev-cli/src/main.rs
+++ b/apps/dev-cli/src/main.rs
@@ -244,18 +244,46 @@ async fn main() -> Result<()> {
 // ═══════════════════════════════════════════════════════════
 
 async fn cmd_serve(r: &mut dyn Renderer, host: String, port: u16) -> Result<()> {
-    r.emit(UiEvent::ServerListening {
-        host: host.clone(),
-        port,
-    });
-
     let mut config =
         oco_orchestrator_core::OrchestratorConfig::load_from_dir(&std::env::current_dir()?);
     config.bind_address = host;
     config.port = port;
 
-    let server = oco_mcp_server::McpServer::new(config);
-    server.run().await?;
+    let mut server = oco_mcp_server::McpServer::new(config);
+
+    // Auto-detect dashboard dist directory.
+    let dashboard_candidates = [
+        PathBuf::from("apps/dashboard/dist"),
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join("dashboard")))
+            .unwrap_or_default(),
+    ];
+    let has_dashboard = if let Some(dir) = std::env::var("OCO_DASHBOARD_DIR")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dashboard_candidates.iter().find(|d| d.join("index.html").exists()).cloned())
+    {
+        server = server.with_dashboard_dir(dir);
+        true
+    } else {
+        false
+    };
+
+    // Bind first to get the real port (especially when --port 0).
+    let (listener, app) = server.bind().await?;
+    let real_addr = listener.local_addr()?;
+
+    r.emit(UiEvent::ServerListening {
+        host: real_addr.ip().to_string(),
+        port: real_addr.port(),
+    });
+
+    if has_dashboard {
+        eprintln!("Dashboard: http://{real_addr}/dashboard");
+    }
+
+    axum::serve(listener, app).await?;
     Ok(())
 }
 

--- a/crates/mcp-server/src/dashboard.rs
+++ b/crates/mcp-server/src/dashboard.rs
@@ -77,6 +77,8 @@ pub struct ReplayListItem {
 /// Dashboard sub-router. Mounted under `/api/v1/dashboard`.
 pub fn dashboard_router() -> Router<Arc<AppState>> {
     Router::new()
+        // Run history (scans .oco/runs/ on disk)
+        .route("/runs", get(list_runs))
         // Replay CRUD + control
         .route("/replays", post(create_replay).get(list_replays))
         .route("/replays/{replay_id}/stream", get(replay_stream))
@@ -87,7 +89,92 @@ pub fn dashboard_router() -> Router<Arc<AppState>> {
         .route("/replays/{replay_id}", axum::routing::delete(delete_replay))
 }
 
+// ── Run history types ────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct RunSummary {
+    pub id: String,
+    pub request: String,
+    pub status: String,
+    pub complexity: String,
+    pub steps: u32,
+    pub tokens_used: u64,
+    pub tokens_max: u64,
+    pub duration_ms: u64,
+    pub success: bool,
+    pub created_at: String,
+    pub run_dir: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct RunsQuery {
+    /// Workspace root to scan for .oco/runs/. Defaults to ".".
+    #[serde(default = "default_workspace")]
+    pub workspace: String,
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+}
+
+fn default_workspace() -> String {
+    ".".into()
+}
+
+fn default_limit() -> usize {
+    20
+}
+
 // ── Handlers ─────────────────────────────────────────────────
+
+/// `GET /api/v1/dashboard/runs` — list recent runs from disk.
+async fn list_runs(
+    Query(query): Query<RunsQuery>,
+) -> Json<Vec<RunSummary>> {
+    // Try the provided workspace, then CWD.
+    let workspace = std::path::Path::new(&query.workspace);
+    let workspace = if workspace.join(".oco").exists() {
+        workspace.to_path_buf()
+    } else {
+        std::env::current_dir().unwrap_or_else(|_| workspace.to_path_buf())
+    };
+    let runs_dir = workspace.join(".oco").join("runs");
+
+    let mut runs = Vec::new();
+
+    if let Ok(entries) = std::fs::read_dir(&runs_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let summary_path = path.join("summary.json");
+            if !summary_path.exists() {
+                continue;
+            }
+            if let Ok(val) = std::fs::read_to_string(&summary_path)
+                .ok()
+                .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+                .ok_or(())
+            {
+                runs.push(RunSummary {
+                    id: val["session_id"].as_str().unwrap_or("?").into(),
+                    request: val["request"].as_str().unwrap_or("").into(),
+                    status: val["status"].as_str().unwrap_or("unknown").into(),
+                    complexity: val["complexity"].as_str().unwrap_or("?").into(),
+                    steps: val["steps"].as_u64().unwrap_or(0) as u32,
+                    tokens_used: val["tokens_used"].as_u64().unwrap_or(0),
+                    tokens_max: val["tokens_max"].as_u64().unwrap_or(0),
+                    duration_ms: val["duration_ms"].as_u64().unwrap_or(0),
+                    success: val["success"].as_bool().unwrap_or(false),
+                    created_at: val["created_at"].as_str().unwrap_or("").into(),
+                    run_dir: path.to_string_lossy().into(),
+                });
+            }
+        }
+    }
+
+    // Sort by created_at descending.
+    runs.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+    runs.truncate(query.limit);
+
+    Json(runs)
+}
 
 /// `POST /api/v1/dashboard/replays` — create a new replay session.
 async fn create_replay(
@@ -111,6 +198,12 @@ async fn create_replay(
     }
 
     let event_count = session.event_count();
+
+    // Spawn the replay loop in the background.
+    let session_for_run = Arc::clone(&session);
+    tokio::spawn(async move {
+        session_for_run.run().await;
+    });
 
     Ok((
         StatusCode::CREATED,
@@ -162,11 +255,13 @@ async fn replay_stream(
             .and_then(|v| v.parse::<u64>().ok())
     });
 
-    // First, send any events the client missed (catch-up).
+    // First, send all pre-existing events (catch-up).
+    // On first connect (no cursor): send everything (replay may already be done).
+    // On reconnect (with cursor): send only what was missed.
     let catchup: Vec<DashboardEvent> = if let Some(seq) = after_seq {
         session.events_after_seq(seq).to_vec()
     } else {
-        Vec::new()
+        session.events().to_vec()
     };
 
     // Then subscribe to live broadcast for new events.

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -94,7 +94,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     // Claude Code HTTP hooks (v2.1.63+) — isolated sub-router with auth + body limit.
     let hooks = crate::hooks::hook_router(Arc::clone(&state));
 
-    Router::new()
+    let mut router = Router::new()
         .route("/health", get(health))
         .route("/api/v1/sessions", post(start_session).get(list_sessions))
         .route("/api/v1/sessions/{session_id}", get(get_session))
@@ -109,8 +109,19 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/v1/search", post(search_workspace))
         .route("/api/v1/mcp", post(mcp_handler))
         .nest("/api/v1/hooks", hooks)
-        .nest("/api/v1/dashboard", crate::dashboard::dashboard_router())
-        .with_state(state)
+        .nest("/api/v1/dashboard", crate::dashboard::dashboard_router());
+
+    // Serve the dashboard static files if the dist directory exists.
+    if let Some(ref dir) = state.dashboard_dir.as_ref().filter(|d| d.exists()) {
+        tracing::info!(path = %dir.display(), "serving dashboard at /dashboard");
+        router = router.nest_service(
+            "/dashboard",
+            tower_http::services::ServeDir::new(dir)
+                .fallback(tower_http::services::ServeFile::new(dir.join("index.html"))),
+        );
+    }
+
+    router.with_state(state)
 }
 
 // ---------------------------------------------------------------------------
@@ -724,6 +735,7 @@ mod tests {
             config,
             session_manager,
             replay_registry: oco_orchestrator_core::replay::ReplayRegistry::new(),
+            dashboard_dir: None,
             hook_secret: None,
         })
     }
@@ -736,6 +748,7 @@ mod tests {
             config,
             session_manager,
             replay_registry: oco_orchestrator_core::replay::ReplayRegistry::new(),
+            dashboard_dir: None,
             hook_secret: Some(secret.to_string()),
         })
     }

--- a/crates/mcp-server/src/server.rs
+++ b/crates/mcp-server/src/server.rs
@@ -17,6 +17,8 @@ pub struct AppState {
     pub session_manager: Arc<SessionManager>,
     /// Manages active replay sessions for the dashboard.
     pub replay_registry: ReplayRegistry,
+    /// Path to the dashboard static files (built Svelte app).
+    pub dashboard_dir: Option<std::path::PathBuf>,
     /// Optional shared secret for authenticating hook requests.
     /// If `None`, hook auth is skipped (dev mode).
     pub hook_secret: Option<String>,
@@ -26,11 +28,16 @@ pub struct AppState {
 pub struct McpServer {
     config: oco_orchestrator_core::OrchestratorConfig,
     llm: Option<Arc<dyn LlmProvider>>,
+    dashboard_dir: Option<std::path::PathBuf>,
 }
 
 impl McpServer {
     pub fn new(config: oco_orchestrator_core::OrchestratorConfig) -> Self {
-        Self { config, llm: None }
+        Self {
+            config,
+            llm: None,
+            dashboard_dir: None,
+        }
     }
 
     /// Set the LLM provider to use for orchestration sessions.
@@ -41,18 +48,28 @@ impl McpServer {
         self
     }
 
-    /// Start the server and listen for connections.
-    pub async fn run(self) -> Result<()> {
+    /// Set the dashboard static files directory.
+    #[must_use]
+    pub fn with_dashboard_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.dashboard_dir = Some(dir);
+        self
+    }
+
+    /// Bind, build the app, and return the listener + app without serving.
+    /// The caller can inspect the bound address before starting.
+    pub async fn bind(
+        self,
+    ) -> Result<(tokio::net::TcpListener, axum::Router)> {
         let addr = format!("{}:{}", self.config.bind_address, self.config.port);
 
         let session_manager = Arc::new(SessionManager::new(self.config.clone(), self.llm));
-
         let hook_secret = std::env::var("OCO_HOOK_SECRET").ok();
 
         let state = Arc::new(AppState {
             config: self.config,
             session_manager,
             replay_registry: ReplayRegistry::new(),
+            dashboard_dir: self.dashboard_dir,
             hook_secret,
         });
 
@@ -60,11 +77,22 @@ impl McpServer {
             .layer(CorsLayer::permissive())
             .layer(TraceLayer::new_for_http());
 
-        tracing::info!("OCO server listening on {addr}");
-
         let listener = tokio::net::TcpListener::bind(&addr).await?;
-        axum::serve(listener, app).await?;
+        Ok((listener, app))
+    }
 
+    /// Start the server and listen for connections.
+    pub async fn run(self) -> Result<()> {
+        let has_dashboard = self.dashboard_dir.is_some();
+        let (listener, app) = self.bind().await?;
+        let local_addr = listener.local_addr()?;
+
+        tracing::info!("OCO server listening on http://{local_addr}");
+        if has_dashboard {
+            tracing::info!("Dashboard: http://{local_addr}/dashboard");
+        }
+
+        axum::serve(listener, app).await?;
         Ok(())
     }
 }

--- a/crates/orchestrator-core/src/replay.rs
+++ b/crates/orchestrator-core/src/replay.rs
@@ -228,15 +228,16 @@ impl ReplaySession {
     /// Run the replay loop — emits events through the broadcast channel
     /// respecting speed and pause controls.
     ///
-    /// This is meant to be spawned as a tokio task.
-    pub async fn run(self) {
-        let events = self.dashboard_events;
-        let tx = self.tx;
-        let mut state_rx = self.state_rx;
-        let mut speed_rx = self.speed_rx;
+    /// Uses clones of internal state so it can be called on `&self` (Arc-friendly).
+    pub async fn run(&self) {
+        let events = self.dashboard_events.clone();
+        let tx = self.tx.clone();
+        let mut state_rx = self.state_rx.clone();
+        let mut speed_rx = self.speed_rx.clone();
+        let controls = self.controls.clone();
 
         if events.is_empty() {
-            let _ = self.controls.state.send(PlaybackState::Finished);
+            let _ = controls.state.send(PlaybackState::Finished);
             return;
         }
 
@@ -278,7 +279,7 @@ impl ReplaySession {
             let _ = tx.send(event);
         }
 
-        let _ = self.controls.state.send(PlaybackState::Finished);
+        let _ = controls.state.send(PlaybackState::Finished);
     }
 }
 
@@ -462,7 +463,7 @@ mod tests {
     #[tokio::test]
     async fn replay_run_emits_all_events() {
         let trace = make_trace(sample_events());
-        let session = ReplaySession::new(&trace);
+        let session = Arc::new(ReplaySession::new(&trace));
         let mut rx = session.subscribe();
         let controls = session.controls();
 
@@ -470,7 +471,8 @@ mod tests {
         controls.set_speed(100.0);
 
         // Run replay in background.
-        tokio::spawn(session.run());
+        let s = Arc::clone(&session);
+        tokio::spawn(async move { s.run().await });
 
         let mut received = Vec::new();
         loop {
@@ -497,10 +499,11 @@ mod tests {
     #[tokio::test]
     async fn replay_empty_trace_finishes_immediately() {
         let trace = make_trace(vec![]);
-        let session = ReplaySession::new(&trace);
+        let session = Arc::new(ReplaySession::new(&trace));
         let controls = session.controls();
 
-        tokio::spawn(session.run());
+        let s = Arc::clone(&session);
+        tokio::spawn(async move { s.run().await });
 
         // Give it a moment.
         tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;

--- a/crates/shared-types/src/dashboard.rs
+++ b/crates/shared-types/src/dashboard.rs
@@ -193,6 +193,23 @@ pub struct ActiveStep {
 
 use crate::telemetry::OrchestrationEvent;
 
+/// Extract a human-readable action type name from an OrchestratorAction.
+fn action_type_name(action: &crate::OrchestratorAction) -> String {
+    use crate::OrchestratorAction;
+    match action {
+        OrchestratorAction::Respond { .. } => "respond".into(),
+        OrchestratorAction::Retrieve { .. } => "retrieve".into(),
+        OrchestratorAction::ToolCall { tool_name, .. } => format!("tool:{tool_name}"),
+        OrchestratorAction::Verify { strategy, .. } => format!("verify:{strategy:?}"),
+        OrchestratorAction::UpdateMemory { .. } => "memory".into(),
+        OrchestratorAction::Stop { reason, .. } => format!("stop:{reason:?}"),
+        OrchestratorAction::Plan { .. } => "plan".into(),
+        OrchestratorAction::Delegate { agent_role, .. } => format!("delegate:{}", agent_role.name),
+        OrchestratorAction::Message { message_type, .. } => format!("message:{message_type:?}"),
+        OrchestratorAction::Replan { .. } => "replan".into(),
+    }
+}
+
 impl DashboardEventKind {
     /// Convert a raw `OrchestrationEvent` into a `DashboardEventKind`.
     ///
@@ -209,7 +226,7 @@ impl DashboardEventKind {
                 ..
             } => DashboardEventKind::FlatStepCompleted {
                 step: *step,
-                action_type: format!("{:?}", std::mem::discriminant(action)),
+                action_type: action_type_name(action),
                 reason: reason.clone(),
                 duration_ms: *duration_ms,
                 budget_snapshot: budget_snapshot.clone(),

--- a/package.json
+++ b/package.json
@@ -17,6 +17,11 @@
     "type": "git",
     "url": "https://github.com/hoklims/oco.git"
   },
+  "scripts": {
+    "dashboard:build": "cd apps/dashboard && npm run build",
+    "dashboard:dev": "cd apps/dashboard && npm run dev",
+    "dashboard:serve": "cd apps/dashboard && npm run build && cd ../.. && cargo run -p oco-dev-cli -- serve --port 0"
+  },
   "license": "Apache-2.0",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary

Complete dashboard redesign with XCOM-inspired tactical interface:

- **Mission select**: card grid with status pips, complexity bars, aggregate stats
- **Mission view**: split-panel operations log + resources + objectives
- **Tactical aesthetic**: dark industrial palette, monospace, scanline overlay, no emojis
- **Narrative log**: human-readable ("RECON — scanned codebase") instead of JSON
- **One-command launch**: `npm run dashboard:serve` (builds + serves on dynamic port)
- **Run history API**: `GET /api/v1/dashboard/runs` scans .oco/runs/ from disk
- **Bugfixes**: replay race condition, action name display, port 0 support

## Test plan

- [x] 596 Rust tests pass, clippy clean
- [x] Dashboard builds in 190ms (58KB JS, 16KB CSS)
- [x] `npm run dashboard:serve` launches server on dynamic port
- [x] Mission cards display 123 runs from .oco/runs/
- [x] Clicking a mission replays events with narrative log
- [x] Budget gauges update from trace data

🤖 Generated with [Claude Code](https://claude.com/claude-code)