### PR TITLE
chore: release v0.14.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.14.3"
+version = "0.14.4"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/open-context-orchestrator/oco"

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "oco-vscode",
   "displayName": "Open Context Orchestrator",
   "description": "Intelligent orchestration middleware for coding assistants",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "publisher": "oco",
   "license": "Apache-2.0",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oco-claude-plugin",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "OCO Claude Code plugin — safety hooks, skills, agents, and MCP tools for any project",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Bump version `0.14.3` → `0.14.4` (1097 tests passing).